### PR TITLE
YASR Feat: Refactored fallback rendering and plugin documentation

### DIFF
--- a/packages/yasr/src/main.scss
+++ b/packages/yasr/src/main.scss
@@ -11,19 +11,18 @@
       align-self: center;
     }
   }
-  .yasr_btn.yasr_downloadIcon div {
-    width: 15px;
-    height: 15px;
-  }
-  .btn_help {
+  .yasr_btn.yasr_external_ref_btn {
     font-weight: 600;
     user-select: none;
-    &:active {
-      color: #428bca;
-      text-decoration-color: #428bca;
+    // Active and focus shouldn't color the button since it'll open a new page
+    &:active,
+    &:focus {
+      color: inherit;
+      text-decoration-color: inherit;
     }
-    &.hidden {
-      display: none;
+    .svgImg svg {
+      width: 18px;
+      height: 18px;
     }
   }
   a {
@@ -77,14 +76,13 @@
     display: flex;
     flex-wrap: wrap;
   }
-  .yasr_help {
+  .yasr_fallback_info:not(:empty) {
     margin-top: 5px;
     border: 1px solid #d1d1d1;
-    padding: 5px;
+    padding: 0.5rem;
     background: #f7f7f7;
-    display: none;
-    &.active {
-      display: block;
+    p {
+      margin: 0;
     }
   }
   .yasr_help_variable {

--- a/packages/yasr/src/plugins/index.ts
+++ b/packages/yasr/src/plugins/index.ts
@@ -11,7 +11,7 @@ export interface Plugin<Opts extends any> {
   draw(persistentConfig: any, runtimeConfig?: any): void;
   getIcon(): Element;
   download?(): DownloadInfo;
-  helpInfo?(): string;
+  helpReference?: string;
 }
 export interface DownloadInfo {
   contentType: string;

--- a/packages/yasr/src/plugins/response/index.ts
+++ b/packages/yasr/src/plugins/response/index.ts
@@ -26,6 +26,7 @@ export default class Response implements Plugin<PluginConfig> {
   private yasr: Yasr;
   label = "Response";
   priority = 2;
+  helpReference = "https://triply.cc/docs/yasgui#response";
   private config: PluginConfig;
   private overLay: HTMLDivElement;
   private cm: CodeMirror.Editor;

--- a/packages/yasr/src/plugins/table/index.ts
+++ b/packages/yasr/src/plugins/table/index.ts
@@ -29,6 +29,7 @@ export default class Table implements Plugin<PluginConfig> {
   private yasr: Yasr;
   private tableControls: Element;
   private dataTable: DataTables.Api;
+  public helpReference = "https://triply.cc/docs/yasgui#table";
   public label = "Table";
   public priority = 10;
   public getIcon() {


### PR DESCRIPTION
- Removed helptext from pluginInterface
- Added helpReference to pluginInterface
- Refactored help_box to fallback_box
- Refactored help_button to info_button

The fallback element will now **always** be drawn when the currently selected plugin isn't able to draw the resultset. The element should make it more clear why the user is not able to see his visualization and when possible supply him with a link to external documentation. 

The help icon will now always display and will provide a link to the documentation of the plugin when possible. As a side effect, the download button has been moved next to the help button in order to make a clear distinction between the plugin selectors and elements that interact with the currently selected plugin