### PR TITLE
Feat: improved autocomplete features

### DIFF
--- a/packages/yasqe/src/autocompleters/prefixes.ts
+++ b/packages/yasqe/src/autocompleters/prefixes.ts
@@ -37,7 +37,11 @@ var conf: Autocompleter.CompleterConfig = {
             (previousToken.type == "ws" ||
               previousToken.type == null ||
               (previousToken.type === "punc" &&
-                (previousToken.string === "|" || previousToken.string === "/" || previousToken.string == "^^")))
+                (previousToken.string === "|" ||
+                  previousToken.string === "/" ||
+                  previousToken.string == "^^" ||
+                  previousToken.string == "{" ||
+                  previousToken.string === "(")))
           ) {
             // check whether it isn't defined already (saves us from looping
             // through the array)

--- a/packages/yasqe/src/tokenUtils.ts
+++ b/packages/yasqe/src/tokenUtils.ts
@@ -23,6 +23,10 @@ function expandTokenToStart(yasqe: Yasqe, token: Token, cur: Position): Token {
     ch: token.start
   });
 
+  if ((token.type === "punc" || token.type === "error") && !token.state.possibleFullIri && !token.state.inPrefixDecl) {
+    token.state.possibleCurrent = token.state.possibleNext;
+    return token;
+  }
   if (prevToken.type === "punc" && !prevToken.state.possibleFullIri && !prevToken.state.inPrefixDecl) {
     //assuming this is a path expression. Should not expand the token anymore
     //Also checking whether current token isnt an error, to avoid stopping on iri path delimiters
@@ -101,7 +105,7 @@ export function getPreviousNonWsToken(yasqe: Yasqe, line: number, token: Token):
   }
   return previousToken;
 }
-export function getNextNonWsToken(yasqe: Yasqe, lineNumber: number, charNumber?: number): Token | undefined{
+export function getNextNonWsToken(yasqe: Yasqe, lineNumber: number, charNumber?: number): Token | undefined {
   if (charNumber == undefined) charNumber = 1;
   var token = yasqe.getTokenAt({
     line: lineNumber,

--- a/test/run.ts
+++ b/test/run.ts
@@ -356,6 +356,46 @@ PREFIX geo: <http://www.opengis.net/ont/geosparql#> select
         const token = await getCompleteToken();
         expect(token.string).to.equal("<http://www.opengis.net/ont/geosparql#");
       });
+
+      it("Autocompleter should show suggestion directly after function #156", async () => {
+        await page.evaluate(() => {
+          const oneLineQuery = "select * where { bind(";
+          window.yasqe.setValue(oneLineQuery);
+          window.yasqe.focus();
+          window.yasqe.getDoc().setCursor({ line: 0, ch: oneLineQuery.indexOf("(") + 1 });
+        });
+        const token = await getCompleteToken();
+        expect(token.state.possibleCurrent).contains(
+          "IRI_REF",
+          `IRI_REF not found in list: "${token.state.possibleCurrent.join('", "')}"`
+        );
+      });
+      it("Autocompleter should show literal suggestion directly after function #156", async () => {
+        await page.evaluate(() => {
+          const oneLineQuery = 'select * where { bind("';
+          window.yasqe.setValue(oneLineQuery);
+          window.yasqe.focus();
+          window.yasqe.getDoc().setCursor({ line: 0, ch: oneLineQuery.indexOf('"') + 1 });
+        });
+        const token = await getCompleteToken();
+        expect(token.state.possibleCurrent).contains(
+          "IRI_REF",
+          `IRI_REF not found in list: "${token.state.possibleCurrent.join('", "')}"`
+        );
+      });
+      it("Autocompleter should show correct results after closing bracket", async () => {
+        await page.evaluate(() => {
+          const oneLineQuery = "select * where { ?s ?p ?o }";
+          window.yasqe.setValue(oneLineQuery);
+          window.yasqe.focus();
+          window.yasqe.getDoc().setCursor({ line: 0, ch: oneLineQuery.indexOf("}") + 1 });
+        });
+        const token = await getCompleteToken();
+        expect(token.state.possibleCurrent).contains(
+          "LIMIT",
+          `LIMIT not found in list: "${token.state.possibleCurrent.join('", "')}"`
+        );
+      });
     });
     /**
      * This test is tricky, as it uses the LOV API in our test. I.e, if this test fails, first check whether LOV is actually up


### PR DESCRIPTION
- getCompleteToken no longer requires a space after puntuation segments
- Prefixes autocompleter now also can trigger directly after `(` and `{`

Partialy fixes #156 