### PR TITLE
Fix: allow for prefixes to start at 1st char

### DIFF
--- a/packages/yasqe/src/prefixFold.ts
+++ b/packages/yasqe/src/prefixFold.ts
@@ -7,7 +7,7 @@ export function findFirstPrefixLine(yasqe: Yasqe) {
   var lastLine = yasqe.getDoc().lastLine();
   for (var i = 0; i <= lastLine; ++i) {
     const firstPrefix = findFirstPrefix(yasqe, i);
-    if (firstPrefix && firstPrefix >= 0) {
+    if (firstPrefix != null && firstPrefix >= 0) {
       return i;
     }
   }


### PR DESCRIPTION
**Problem**: Yasqe does not collapse prefixes if the first one starts on the first character.

**To reproduce**: 
```
<div id="yasgui"></div>
<script>
   const yasgui = new Yasgui(document.getElementById("yasgui"));
   const tab = yasgui.getTab();
   tab.setQuery(
      "PREFIX one: <https://example.org/one/>" + "\n" +
      "PREFIX two: <https://example.org/two/>"
   );
   tab.yasqe.collapsePrefixes();
</script>
```

**Cause**: Condition `(firstPrefix && firstPrefix >= 0)` in `findFirstPrefixLine` reads character index `0` as `false` while checking for `null` values.

**Fix**: Change to `(firstPrefix != null && firstPrefix >= 0)`.