### PR TITLE
Fix dependency update that broke Yasr (@types/superagent 4.1.4 => 4.1.7)

### DIFF
--- a/packages/yasr/src/parsers/index.ts
+++ b/packages/yasr/src/parsers/index.ts
@@ -103,7 +103,7 @@ class Parser {
           // message: this.res.error.message,
           text: this.res.text,
           status: this.res.status,
-          statusText: this.res.error.text
+          statusText: this.res.error ? this.res.error.text : ""
         };
       }
       if (this.summary && this.summary.error) {
@@ -207,8 +207,8 @@ class Parser {
 
   public getVariables(): string[] {
     var json = this.getAsJson();
-    if (json && json.head) return json.head.vars
-    return []
+    if (json && json.head) return json.head.vars;
+    return [];
   }
 
   public getBoolean(): boolean | undefined {
@@ -244,7 +244,7 @@ class Parser {
     if (!this.type) this.getAsJson(); //detects type as well
     return this.type;
   }
-  getStatus(): number  | undefined{
+  getStatus(): number | undefined {
     if (this.res) return this.res.status;
     if (this.summary) return this.summary.status;
   }

--- a/packages/yasr/src/parsers/index.ts
+++ b/packages/yasr/src/parsers/index.ts
@@ -103,7 +103,7 @@ class Parser {
           // message: this.res.error.message,
           text: this.res.text,
           status: this.res.status,
-          statusText: this.res.error ? this.res.error.text : ""
+          statusText: this.res.error ? this.res.error.text : undefined
         };
       }
       if (this.summary && this.summary.error) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2978,7 +2978,7 @@
     "@types/domutils" "*"
     "@types/node" "*"
 
-"@types/jquery@*", "@types/jquery@3.3.31", "@types/jquery@^3.3.22":
+"@types/jquery@*", "@types/jquery@^3.3.22":
   version "3.3.31"
   resolved "https://registry.yarnpkg.com/@types/jquery/-/jquery-3.3.31.tgz#27c706e4bf488474e1cb54a71d8303f37c93451b"
   integrity sha512-Lz4BAJihoFw5nRzKvg4nawXPzutkv7wmfQ5121avptaSIXlDNJCUuxZxX/G+9EVidZGuO0UBlk+YjKbwRKJigg==
@@ -3065,9 +3065,9 @@
     "@types/node" "*"
 
 "@types/node@*":
-  version "12.0.10"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.0.10.tgz#51babf9c7deadd5343620055fc8aff7995c8b031"
-  integrity sha512-LcsGbPomWsad6wmMNv7nBLw7YYYyfdYcz6xryKYQhx89c3XXan+8Q6AJ43G5XDIaklaVkK3mE4fCb0SBvMiPSQ==
+  version "14.0.11"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.11.tgz#61d4886e2424da73b7b25547f59fdcb534c165a3"
+  integrity sha512-lCvvI24L21ZVeIiyIUHZ5Oflv1hhHQ5E1S25IRlKIXaRkVgmXpJMI3wUJkmym2bTbCe+WoIibQnMVAU3FguaOg==
 
 "@types/node@13.5.0":
   version "13.5.0"
@@ -3108,7 +3108,7 @@
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.2.tgz#690a1475b84f2a884fd07cd797c00f5f31356ea8"
   integrity sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==
 
-"@types/rdf-js@*", "@types/rdf-js@2.0.10":
+"@types/rdf-js@*":
   version "2.0.10"
   resolved "https://registry.yarnpkg.com/@types/rdf-js/-/rdf-js-2.0.10.tgz#48cbb55044bc9e3e100f7e7261e66994a17836ff"
   integrity sha512-p6jynQltGUe/7Lr7z/Op6GiQ7XE/HKVMqtMs/67DYPCIuADXC0lXjgIKY6Kcv6Sh3HFnGL/UCcgnHGsrYG+xSA==
@@ -3138,9 +3138,9 @@
   integrity sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==
 
 "@types/superagent@^4.1.4":
-  version "4.1.4"
-  resolved "https://registry.yarnpkg.com/@types/superagent/-/superagent-4.1.4.tgz#63f74955a28073870cfd9c100bcacb26d72b3764"
-  integrity sha512-SRH2q6/5/nhOkAuLXm3azRGjBYpoKCZWh138Rt1AxSIyE6/1b9uClIH2V+JfyDtjIvgr5yQqYgNUmdpbneJoZQ==
+  version "4.1.7"
+  resolved "https://registry.yarnpkg.com/@types/superagent/-/superagent-4.1.7.tgz#a7d92d98c490ee0f802a127fdf149b9a114f77a5"
+  integrity sha512-JSwNPgRYjIC4pIeOqLwWwfGj6iP1n5NE6kNBEbGx2V8H78xCPwx7QpNp9plaI30+W3cFEzJO7BIIsXE+dbtaGg==
   dependencies:
     "@types/cookiejar" "*"
     "@types/node" "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2978,7 +2978,7 @@
     "@types/domutils" "*"
     "@types/node" "*"
 
-"@types/jquery@*", "@types/jquery@^3.3.22":
+"@types/jquery@*", "@types/jquery@3.3.31", "@types/jquery@^3.3.22":
   version "3.3.31"
   resolved "https://registry.yarnpkg.com/@types/jquery/-/jquery-3.3.31.tgz#27c706e4bf488474e1cb54a71d8303f37c93451b"
   integrity sha512-Lz4BAJihoFw5nRzKvg4nawXPzutkv7wmfQ5121avptaSIXlDNJCUuxZxX/G+9EVidZGuO0UBlk+YjKbwRKJigg==
@@ -3108,7 +3108,7 @@
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.2.tgz#690a1475b84f2a884fd07cd797c00f5f31356ea8"
   integrity sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==
 
-"@types/rdf-js@*":
+"@types/rdf-js@*", "@types/rdf-js@2.0.10":
   version "2.0.10"
   resolved "https://registry.yarnpkg.com/@types/rdf-js/-/rdf-js-2.0.10.tgz#48cbb55044bc9e3e100f7e7261e66994a17836ff"
   integrity sha512-p6jynQltGUe/7Lr7z/Op6GiQ7XE/HKVMqtMs/67DYPCIuADXC0lXjgIKY6Kcv6Sh3HFnGL/UCcgnHGsrYG+xSA==


### PR DESCRIPTION
**Problem**: While working on #162 I stumbled upon an issue in the Yasr code, after upgrading dependencies. Turned out to be caused by `@types/superagent`, in a minor change (`4.1.4 => 4.1.7`).

**To reproduce**: Selectively/interactively upgrade `@types/superagent`, then try to build Yasr.

**Cause**: The superagent update changed the type of it's `Response.error` from `ResponseError` to the union type `false | HTTPError`. This breaks a call to `error.text` in `yasr/src/parsers/index.ts`.

**Fix**: Added a boolean check to see whether or not the error is indeed a `HTTPError`.

**Discussion**: 
- My commit inserts an empty string if the error is `false`. If desired, this could be something else.
- The commit apparently contains some Husky formatting changes to the same document. If undesired, these could be left out.