### PR TITLE
Fix: devDependency update for Yasqe and Yasr (@types/codemirror 0.0.8…

### DIFF
--- a/packages/yasqe/package.json
+++ b/packages/yasqe/package.json
@@ -44,7 +44,7 @@
     "@triply/yasgui": "4.x"
   },
   "devDependencies": {
-    "@types/codemirror": "0.0.84",
+    "@types/codemirror": "0.0.96",
     "@types/node": "13.5.0",
     "@types/superagent": "^4.1.4",
     "npm-check": "^5.9.0"

--- a/packages/yasr/package.json
+++ b/packages/yasr/package.json
@@ -52,7 +52,7 @@
     "@triply/yasgui": "4.x"
   },
   "devDependencies": {
-    "@types/codemirror": "0.0.84",
+    "@types/codemirror": "0.0.96",
     "@types/datatables.net": "^1.10.18",
     "@types/dompurify": "^2.0.1",
     "@types/jquery": "^3.3.22",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1676,10 +1676,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/codemirror@0.0.84":
-  version "0.0.84"
-  resolved "https://registry.yarnpkg.com/@types/codemirror/-/codemirror-0.0.84.tgz#b0cfca79ccdfd45ffe1f737668276a31b3149ebd"
-  integrity sha512-W78ZhfHPGYoYGCpAcEa268QUU3CVMA8BwcybxUMhEs2v5Rj58/7lGeRh3P7tauWRnSg3Pyn5ymw2lt65AyrVUw==
+"@types/codemirror@0.0.96":
+  version "0.0.96"
+  resolved "https://registry.yarnpkg.com/@types/codemirror/-/codemirror-0.0.96.tgz#73b52e784a246cebef31d544fef45ea764de5bad"
+  integrity sha512-GTswEV26Bl1byRxpD3sKd1rT2AISr0rK9ImlJgEzfvqhcVWeu4xQKFQI6UgSC95NT5swNG4st/oRMeGVZgPj9w==
   dependencies:
     "@types/tern" "*"
 


### PR DESCRIPTION
`ERROR in /path/to/node_modules/@triply/yasqe/build/ts/src/index.d.ts(156,47): `

```
    154 |         maxHighlightLength?: number;
    155 |         viewportMargin?: number;
  > 156 |         lint?: boolean | import("codemirror").LintOptions;
        |                                               ^
    157 |         placeholder?: string;
    158 |         collapsePrefixesOnLoad: boolean;
    159 |         syntaxErrorCheck: boolean;
```

---

1. I use `Yarn` and ran the command `yarn add @triply/yasgui` according to [the documentation you provided](https://triply.cc/docs/yasgui-api#yarn).
2. I'm developing in `nuxt` + `typescript`, so I got an error that says to install a type definition file (details are as follows).
>```
> Could not find a declaration file for module 'codemirror'. 
> '/path/to/node_modules/codemirror/lib/codemirror.js' implicitly has an 'any' type.
> Try `npm install @types/codemirror` if it exists or add a new declaration (.d.ts) file containing `declare module 'codemirror';`
>   > 1 | import { Editor as CmEditor, Doc as CmDoc, Token as CmToken, Position as CmPosition, EditorConfiguration as CmEditorConfiguration } from "codemirror";
> ```

3. Following the error message, `yarn add @types/codemirror` was executed, replacing the `npm` command with `yarn`.
4. Some errors have disappeared, but there is one error that I can't seem to fix. That error is shown in the opening paragraph of this issue.

---

**my proposal:**

On the repository of [`@types/codemirror`](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/codemirror), there was an [MERGE update](https://github.com/DefinitelyTyped/DefinitelyTyped/commit/e6ef02255493829dd59e256a210e500cb920f8aa#diff-3ad9f9473e8ea6885957422d59660579) about a month ago that changed `LintOption` to `LintStateOptions | Linter | AsyncLinter`. Therefore, I think `Yasqe` (and `Yasr`) should follow this change.

cf. [🤖 Merge PR #45097 [codemirror] Add additional lint options by @youngbob · DefinitelyTyped/DefinitelyTyped@e6ef022](https://github.com/DefinitelyTyped/DefinitelyTyped/commit/e6ef02255493829dd59e256a210e500cb920f8aa#diff-3ad9f9473e8ea6885957422d59660579)


After build, the relevant part of `index.d.ts` will be changed as follows.

```diff
-   lint?: boolean | import("codemirror").LintOptions;
-                                        ^
+   lint?: boolean | import("codemirror").LintStateOptions | import("codemirror").Linter | import("codemirror").AsyncLinter;
```

