### PR TITLE
No longer ignoring text of non-http Errors

### DIFF
--- a/packages/yasr/src/plugins/error/index.ts
+++ b/packages/yasr/src/plugins/error/index.ts
@@ -108,7 +108,13 @@ export default class Error implements Plugin<PluginConfig> {
         const link = this.yasr.config.getPlainQueryLinkToEndpoint();
         if (link) header.appendChild(this.getTryBtn(link));
       }
-      el.appendChild(this.getCorsMessage());
+      if (error.text) {
+        const errTextEl = document.createElement("pre");
+        errTextEl.textContent = error.text;
+        el.appendChild(errTextEl);
+      } else {
+        el.appendChild(this.getCorsMessage());
+      }
     }
   }
   getIcon() {


### PR DESCRIPTION
Currently the valuable text in `yasr.setResponse(Error('valuable text'))` is not shown to the user