### PR TITLE
Feat: add default prefix API url in config #202

### DIFF
--- a/packages/yasqe/src/autocompleters/prefixes.ts
+++ b/packages/yasqe/src/autocompleters/prefixes.ts
@@ -4,8 +4,6 @@ var tokenTypes: { [id: string]: "prefixed" | "var" } = {
   "string-2": "prefixed",
   atom: "var",
 };
-const prefixCcApi =
-  (window.location.protocol.indexOf("http") === 0 ? "//" : "http://") + "prefix.cc/popular/all.file.json";
 import * as superagent from "superagent";
 
 var conf: Autocompleter.CompleterConfig = {
@@ -92,8 +90,8 @@ var conf: Autocompleter.CompleterConfig = {
     if (!previousToken || previousToken.string.toUpperCase() != "PREFIX") return false;
     return true;
   },
-  get: function (_token) {
-    return superagent.get(prefixCcApi).then((resp) => {
+  get: function (yasqe) {
+    return superagent.get(yasqe.config.prefixCcApi).then((resp) => {
       var prefixArray: string[] = [];
       for (var prefix in resp.body) {
         var completeString = prefix + ": <" + resp.body[prefix] + ">";

--- a/packages/yasqe/src/defaults.ts
+++ b/packages/yasqe/src/defaults.ts
@@ -8,6 +8,8 @@ import { default as Yasqe, Config, PlainRequestConfig } from "./";
 import * as queryString from "query-string";
 //need to pass Yasqe object as argument, as the imported version might not have inherited all (e.g. `fold`) props of Codemirror yet
 export default function get() {
+  const prefixCcApi =
+    (window.location.protocol.indexOf("http") === 0 ? "//" : "http://") + "prefix.cc/popular/all.file.json";
   const CodeMirror = require("codemirror");
   const config: Omit<Config, "requestConfig"> = {
     mode: "sparql11",
@@ -128,6 +130,7 @@ SELECT * WHERE {
     resizeable: true,
     editorHeight: "300px",
     queryingDisabled: undefined,
+    prefixCcApi: prefixCcApi,
   };
   const requestConfig: PlainRequestConfig = {
     queryArgument: undefined, //undefined means: get query argument based on query mode

--- a/packages/yasqe/src/index.ts
+++ b/packages/yasqe/src/index.ts
@@ -1037,6 +1037,7 @@ export interface Config extends Partial<CodeMirror.EditorConfiguration> {
   resizeable: boolean;
   editorHeight: string;
   queryingDisabled: string | undefined; // The string will be the message displayed when hovered
+  prefixCcApi: string; // the suggested default prefixes URL API getter
 }
 export interface PersistentConfig {
   query: string;


### PR DESCRIPTION
Fix the issue #202 allow to add in the config the prefix API url for YASQE instead of using the default one