### PR TITLE
Alter text for Ellipse

### DIFF
--- a/packages/yasr/src/plugins/table/index.ts
+++ b/packages/yasr/src/plugins/table/index.ts
@@ -333,7 +333,7 @@ export default class Table implements Plugin<PluginConfig> {
     const ellipseToggleWrapper = document.createElement("div");
     const ellipseSwitchComponent = document.createElement("label");
     const ellipseTextComponent = document.createElement("span");
-    ellipseTextComponent.innerText = "Ellipse";
+    ellipseTextComponent.innerText = "Ellipsis";
     addClass(ellipseTextComponent, "label");
     ellipseSwitchComponent.appendChild(ellipseTextComponent);
     addClass(ellipseSwitchComponent, "switch");


### PR DESCRIPTION
I think we want Ellipsis:

https://en.wikipedia.org/wiki/Ellipsis

here rather than Ellipse which is a shape in geometry.

I don't think there's a compelling reason to change all the variable names though, just the label the user sees.