### PR TITLE
Use older swi prolog 7.5.11 to build YASQE grammar

### DIFF
--- a/packages/yasqe/grammar/README.md
+++ b/packages/yasqe/grammar/README.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- SWI Prolog
+- SWI Prolog 7.x
 
 ## How to make modifications to grammar:
 

--- a/packages/yasqe/grammar/build.sh
+++ b/packages/yasqe/grammar/build.sh
@@ -1,2 +1,10 @@
 #!/bin/bash
-swipl  -s util/gen_sparql11.pl -t go
+set -eu
+
+docker pull swipl:7.5.11
+docker container run --rm \
+  --volume $(pwd -P):/app \
+  --workdir /app \
+  --user 1000:1000 \
+  swipl:7.5.11 \
+  swipl -s /app/util/gen_sparql11.pl -t go


### PR DESCRIPTION
Related to #190 

Using the latest SWIPL for Ubuntu, 9.0.3, results in:

```bash
kinow@ranma:~/Development/java/jena/Yasgui/packages/yasqe/grammar$ ./build.sh 
Welcome to SWI-Prolog (threaded, 64 bits, version 9.0.3)
SWI-Prolog comes with ABSOLUTELY NO WARRANTY. This is free software.
Please run ?- license. for legal details.

For online help and background, visit https://www.swi-prolog.org
For built-in help, use ?- help(Topic). or ?- apropos(Word).

ERROR: assertz/1: Type error: `callable' expected, found `[]' (an empty_list)
```

This PR makes the prolog command pass and the SPARQL grammar to be generated successfully.

Cheers,
-Bruno