### PR TITLE
Add support to SPARQL-Star

### DIFF
--- a/packages/yasqe/grammar/README.md
+++ b/packages/yasqe/grammar/README.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- SWI Prolog
+- SWI Prolog 7.x
 
 ## How to make modifications to grammar:
 

--- a/packages/yasqe/grammar/_tokenizer-table.js
+++ b/packages/yasqe/grammar/_tokenizer-table.js
@@ -6,17 +6,109 @@ module.exports = {
       ")": [],
       ",": [],
       "||": [],
-      ";": []
+      "!": [],
+      "+": [],
+      "-": [],
+      VAR1: [],
+      VAR2: [],
+      "(": [],
+      STR: [],
+      LANG: [],
+      LANGMATCHES: [],
+      DATATYPE: [],
+      BOUND: [],
+      IRI: [],
+      URI: [],
+      BNODE: [],
+      RAND: [],
+      ABS: [],
+      CEIL: [],
+      FLOOR: [],
+      ROUND: [],
+      CONCAT: [],
+      STRLEN: [],
+      UCASE: [],
+      LCASE: [],
+      ENCODE_FOR_URI: [],
+      CONTAINS: [],
+      STRSTARTS: [],
+      STRENDS: [],
+      STRBEFORE: [],
+      STRAFTER: [],
+      YEAR: [],
+      MONTH: [],
+      DAY: [],
+      HOURS: [],
+      MINUTES: [],
+      SECONDS: [],
+      TIMEZONE: [],
+      TZ: [],
+      NOW: [],
+      UUID: [],
+      STRUUID: [],
+      MD5: [],
+      SHA1: [],
+      SHA256: [],
+      SHA384: [],
+      SHA512: [],
+      COALESCE: [],
+      IF: [],
+      STRLANG: [],
+      STRDT: [],
+      SAMETERM: [],
+      ISIRI: [],
+      ISURI: [],
+      ISBLANK: [],
+      ISLITERAL: [],
+      ISNUMERIC: [],
+      TRIPLE: [],
+      SUBJECT: [],
+      PREDICATE: [],
+      OBJECT: [],
+      isTRIPLE: [],
+      TRUE: [],
+      FALSE: [],
+      "<<": [],
+      COUNT: [],
+      SUM: [],
+      MIN: [],
+      MAX: [],
+      AVG: [],
+      SAMPLE: [],
+      GROUP_CONCAT: [],
+      SUBSTR: [],
+      REPLACE: [],
+      REGEX: [],
+      EXISTS: [],
+      NOT: [],
+      IRI_REF: [],
+      STRING_LITERAL1: [],
+      STRING_LITERAL2: [],
+      STRING_LITERAL_LONG1: [],
+      STRING_LITERAL_LONG2: [],
+      INTEGER: [],
+      DECIMAL: [],
+      DOUBLE: [],
+      INTEGER_POSITIVE: [],
+      DECIMAL_POSITIVE: [],
+      DOUBLE_POSITIVE: [],
+      INTEGER_NEGATIVE: [],
+      DECIMAL_NEGATIVE: [],
+      DOUBLE_NEGATIVE: [],
+      PNAME_LN: [],
+      PNAME_NS: [],
+      ";": [],
     },
     "*[,,expression]": {
       ",": ["[,,expression]", "*[,,expression]"],
-      ")": []
+      ")": [],
     },
     "*[,,objectPath]": {
       ",": ["[,,objectPath]", "*[,,objectPath]"],
       ".": [],
       ";": [],
       "]": [],
+      "|}": [],
       "{": [],
       OPTIONAL: [],
       MINUS: [],
@@ -25,13 +117,14 @@ module.exports = {
       FILTER: [],
       BIND: [],
       VALUES: [],
-      "}": []
+      "}": [],
     },
     "*[,,object]": {
       ",": ["[,,object]", "*[,,object]"],
       ".": [],
       ";": [],
       "]": [],
+      "|}": [],
       "}": [],
       GRAPH: [],
       "{": [],
@@ -40,17 +133,18 @@ module.exports = {
       SERVICE: [],
       FILTER: [],
       BIND: [],
-      VALUES: []
+      VALUES: [],
     },
     "*[/,pathEltOrInverse]": {
       "/": ["[/,pathEltOrInverse]", "*[/,pathEltOrInverse]"],
       "|": [],
       ")": [],
-      "(": [],
-      "[": [],
       VAR1: [],
       VAR2: [],
       NIL: [],
+      "<<": [],
+      "(": [],
+      "[": [],
       IRI_REF: [],
       TRUE: [],
       FALSE: [],
@@ -70,12 +164,13 @@ module.exports = {
       DOUBLE_POSITIVE: [],
       INTEGER_NEGATIVE: [],
       DECIMAL_NEGATIVE: [],
-      DOUBLE_NEGATIVE: []
+      DOUBLE_NEGATIVE: [],
     },
     "*[;,?[or([verbPath,verbSimple]),objectListPath]]": {
       ";": ["[;,?[or([verbPath,verbSimple]),objectListPath]]", "*[;,?[or([verbPath,verbSimple]),objectListPath]]"],
       ".": [],
       "]": [],
+      "|}": [],
       "{": [],
       OPTIONAL: [],
       MINUS: [],
@@ -84,12 +179,13 @@ module.exports = {
       FILTER: [],
       BIND: [],
       VALUES: [],
-      "}": []
+      "}": [],
     },
     "*[;,?[verb,objectList]]": {
       ";": ["[;,?[verb,objectList]]", "*[;,?[verb,objectList]]"],
       ".": [],
       "]": [],
+      "|}": [],
       "}": [],
       GRAPH: [],
       "{": [],
@@ -98,20 +194,21 @@ module.exports = {
       SERVICE: [],
       FILTER: [],
       BIND: [],
-      VALUES: []
+      VALUES: [],
     },
     "*[UNION,groupGraphPattern]": {
       UNION: ["[UNION,groupGraphPattern]", "*[UNION,groupGraphPattern]"],
       VAR1: [],
       VAR2: [],
       NIL: [],
-      "(": [],
-      "[": [],
+      "<<": [],
       IRI_REF: [],
       TRUE: [],
       FALSE: [],
       BLANK_NODE_LABEL: [],
       ANON: [],
+      "(": [],
+      "[": [],
       PNAME_LN: [],
       PNAME_NS: [],
       STRING_LITERAL1: [],
@@ -136,7 +233,7 @@ module.exports = {
       FILTER: [],
       BIND: [],
       VALUES: [],
-      "}": []
+      "}": [],
     },
     "*[graphPatternNotTriples,?.,?triplesBlock]": {
       "{": ["[graphPatternNotTriples,?.,?triplesBlock]", "*[graphPatternNotTriples,?.,?triplesBlock]"],
@@ -147,24 +244,25 @@ module.exports = {
       FILTER: ["[graphPatternNotTriples,?.,?triplesBlock]", "*[graphPatternNotTriples,?.,?triplesBlock]"],
       BIND: ["[graphPatternNotTriples,?.,?triplesBlock]", "*[graphPatternNotTriples,?.,?triplesBlock]"],
       VALUES: ["[graphPatternNotTriples,?.,?triplesBlock]", "*[graphPatternNotTriples,?.,?triplesBlock]"],
-      "}": []
+      "}": [],
     },
     "*[quadsNotTriples,?.,?triplesTemplate]": {
       GRAPH: ["[quadsNotTriples,?.,?triplesTemplate]", "*[quadsNotTriples,?.,?triplesTemplate]"],
-      "}": []
+      "}": [],
     },
     "*[|,pathOneInPropertySet]": {
       "|": ["[|,pathOneInPropertySet]", "*[|,pathOneInPropertySet]"],
-      ")": []
+      ")": [],
     },
     "*[|,pathSequence]": {
       "|": ["[|,pathSequence]", "*[|,pathSequence]"],
       ")": [],
-      "(": [],
-      "[": [],
       VAR1: [],
       VAR2: [],
       NIL: [],
+      "<<": [],
+      "(": [],
+      "[": [],
       IRI_REF: [],
       TRUE: [],
       FALSE: [],
@@ -184,17 +282,109 @@ module.exports = {
       DOUBLE_POSITIVE: [],
       INTEGER_NEGATIVE: [],
       DECIMAL_NEGATIVE: [],
-      DOUBLE_NEGATIVE: []
+      DOUBLE_NEGATIVE: [],
     },
     "*[||,conditionalAndExpression]": {
       "||": ["[||,conditionalAndExpression]", "*[||,conditionalAndExpression]"],
       AS: [],
       ")": [],
       ",": [],
-      ";": []
+      "!": [],
+      "+": [],
+      "-": [],
+      VAR1: [],
+      VAR2: [],
+      "(": [],
+      STR: [],
+      LANG: [],
+      LANGMATCHES: [],
+      DATATYPE: [],
+      BOUND: [],
+      IRI: [],
+      URI: [],
+      BNODE: [],
+      RAND: [],
+      ABS: [],
+      CEIL: [],
+      FLOOR: [],
+      ROUND: [],
+      CONCAT: [],
+      STRLEN: [],
+      UCASE: [],
+      LCASE: [],
+      ENCODE_FOR_URI: [],
+      CONTAINS: [],
+      STRSTARTS: [],
+      STRENDS: [],
+      STRBEFORE: [],
+      STRAFTER: [],
+      YEAR: [],
+      MONTH: [],
+      DAY: [],
+      HOURS: [],
+      MINUTES: [],
+      SECONDS: [],
+      TIMEZONE: [],
+      TZ: [],
+      NOW: [],
+      UUID: [],
+      STRUUID: [],
+      MD5: [],
+      SHA1: [],
+      SHA256: [],
+      SHA384: [],
+      SHA512: [],
+      COALESCE: [],
+      IF: [],
+      STRLANG: [],
+      STRDT: [],
+      SAMETERM: [],
+      ISIRI: [],
+      ISURI: [],
+      ISBLANK: [],
+      ISLITERAL: [],
+      ISNUMERIC: [],
+      TRIPLE: [],
+      SUBJECT: [],
+      PREDICATE: [],
+      OBJECT: [],
+      isTRIPLE: [],
+      TRUE: [],
+      FALSE: [],
+      "<<": [],
+      COUNT: [],
+      SUM: [],
+      MIN: [],
+      MAX: [],
+      AVG: [],
+      SAMPLE: [],
+      GROUP_CONCAT: [],
+      SUBSTR: [],
+      REPLACE: [],
+      REGEX: [],
+      EXISTS: [],
+      NOT: [],
+      IRI_REF: [],
+      STRING_LITERAL1: [],
+      STRING_LITERAL2: [],
+      STRING_LITERAL_LONG1: [],
+      STRING_LITERAL_LONG2: [],
+      INTEGER: [],
+      DECIMAL: [],
+      DOUBLE: [],
+      INTEGER_POSITIVE: [],
+      DECIMAL_POSITIVE: [],
+      DOUBLE_POSITIVE: [],
+      INTEGER_NEGATIVE: [],
+      DECIMAL_NEGATIVE: [],
+      DOUBLE_NEGATIVE: [],
+      PNAME_LN: [],
+      PNAME_NS: [],
+      ";": [],
     },
     "*dataBlockValue": {
       UNDEF: ["dataBlockValue", "*dataBlockValue"],
+      "<<": ["dataBlockValue", "*dataBlockValue"],
       IRI_REF: ["dataBlockValue", "*dataBlockValue"],
       TRUE: ["dataBlockValue", "*dataBlockValue"],
       FALSE: ["dataBlockValue", "*dataBlockValue"],
@@ -214,12 +404,12 @@ module.exports = {
       DECIMAL_NEGATIVE: ["dataBlockValue", "*dataBlockValue"],
       DOUBLE_NEGATIVE: ["dataBlockValue", "*dataBlockValue"],
       "}": [],
-      ")": []
+      ")": [],
     },
     "*datasetClause": {
       FROM: ["datasetClause", "*datasetClause"],
       WHERE: [],
-      "{": []
+      "{": [],
     },
     "*describeDatasetClause": {
       FROM: ["describeDatasetClause", "*describeDatasetClause"],
@@ -231,14 +421,15 @@ module.exports = {
       WHERE: [],
       "{": [],
       VALUES: [],
-      $: []
+      $: [],
     },
     "*graphNode": {
-      "(": ["graphNode", "*graphNode"],
-      "[": ["graphNode", "*graphNode"],
       VAR1: ["graphNode", "*graphNode"],
       VAR2: ["graphNode", "*graphNode"],
       NIL: ["graphNode", "*graphNode"],
+      "<<": ["graphNode", "*graphNode"],
+      "(": ["graphNode", "*graphNode"],
+      "[": ["graphNode", "*graphNode"],
       IRI_REF: ["graphNode", "*graphNode"],
       TRUE: ["graphNode", "*graphNode"],
       FALSE: ["graphNode", "*graphNode"],
@@ -259,14 +450,15 @@ module.exports = {
       INTEGER_NEGATIVE: ["graphNode", "*graphNode"],
       DECIMAL_NEGATIVE: ["graphNode", "*graphNode"],
       DOUBLE_NEGATIVE: ["graphNode", "*graphNode"],
-      ")": []
+      ")": [],
     },
     "*graphNodePath": {
-      "(": ["graphNodePath", "*graphNodePath"],
-      "[": ["graphNodePath", "*graphNodePath"],
       VAR1: ["graphNodePath", "*graphNodePath"],
       VAR2: ["graphNodePath", "*graphNodePath"],
       NIL: ["graphNodePath", "*graphNodePath"],
+      "<<": ["graphNodePath", "*graphNodePath"],
+      "(": ["graphNodePath", "*graphNodePath"],
+      "[": ["graphNodePath", "*graphNodePath"],
       IRI_REF: ["graphNodePath", "*graphNodePath"],
       TRUE: ["graphNodePath", "*graphNodePath"],
       FALSE: ["graphNodePath", "*graphNodePath"],
@@ -287,7 +479,7 @@ module.exports = {
       INTEGER_NEGATIVE: ["graphNodePath", "*graphNodePath"],
       DECIMAL_NEGATIVE: ["graphNodePath", "*graphNodePath"],
       DOUBLE_NEGATIVE: ["graphNodePath", "*graphNodePath"],
-      ")": []
+      ")": [],
     },
     "*groupCondition": {
       "(": ["groupCondition", "*groupCondition"],
@@ -340,6 +532,11 @@ module.exports = {
       ISBLANK: ["groupCondition", "*groupCondition"],
       ISLITERAL: ["groupCondition", "*groupCondition"],
       ISNUMERIC: ["groupCondition", "*groupCondition"],
+      TRIPLE: ["groupCondition", "*groupCondition"],
+      SUBJECT: ["groupCondition", "*groupCondition"],
+      PREDICATE: ["groupCondition", "*groupCondition"],
+      OBJECT: ["groupCondition", "*groupCondition"],
+      isTRIPLE: ["groupCondition", "*groupCondition"],
       VAR1: ["groupCondition", "*groupCondition"],
       VAR2: ["groupCondition", "*groupCondition"],
       SUBSTR: ["groupCondition", "*groupCondition"],
@@ -356,7 +553,7 @@ module.exports = {
       ORDER: [],
       HAVING: [],
       $: [],
-      "}": []
+      "}": [],
     },
     "*havingCondition": {
       "(": ["havingCondition", "*havingCondition"],
@@ -409,6 +606,11 @@ module.exports = {
       ISBLANK: ["havingCondition", "*havingCondition"],
       ISLITERAL: ["havingCondition", "*havingCondition"],
       ISNUMERIC: ["havingCondition", "*havingCondition"],
+      TRIPLE: ["havingCondition", "*havingCondition"],
+      SUBJECT: ["havingCondition", "*havingCondition"],
+      PREDICATE: ["havingCondition", "*havingCondition"],
+      OBJECT: ["havingCondition", "*havingCondition"],
+      isTRIPLE: ["havingCondition", "*havingCondition"],
       SUBSTR: ["havingCondition", "*havingCondition"],
       REPLACE: ["havingCondition", "*havingCondition"],
       REGEX: ["havingCondition", "*havingCondition"],
@@ -422,12 +624,12 @@ module.exports = {
       OFFSET: [],
       ORDER: [],
       $: [],
-      "}": []
+      "}": [],
     },
     "*or([[(,*dataBlockValue,)],NIL])": {
       "(": ["or([[(,*dataBlockValue,)],NIL])", "*or([[(,*dataBlockValue,)],NIL])"],
       NIL: ["or([[(,*dataBlockValue,)],NIL])", "*or([[(,*dataBlockValue,)],NIL])"],
-      "}": []
+      "}": [],
     },
     "*or([[*,unaryExpression],[/,unaryExpression]])": {
       "*": ["or([[*,unaryExpression],[/,unaryExpression]])", "*or([[*,unaryExpression],[/,unaryExpression]])"],
@@ -453,40 +655,122 @@ module.exports = {
       INTEGER_NEGATIVE: [],
       DECIMAL_NEGATIVE: [],
       DOUBLE_NEGATIVE: [],
-      ";": []
+      "!": [],
+      VAR1: [],
+      VAR2: [],
+      "(": [],
+      STR: [],
+      LANG: [],
+      LANGMATCHES: [],
+      DATATYPE: [],
+      BOUND: [],
+      IRI: [],
+      URI: [],
+      BNODE: [],
+      RAND: [],
+      ABS: [],
+      CEIL: [],
+      FLOOR: [],
+      ROUND: [],
+      CONCAT: [],
+      STRLEN: [],
+      UCASE: [],
+      LCASE: [],
+      ENCODE_FOR_URI: [],
+      CONTAINS: [],
+      STRSTARTS: [],
+      STRENDS: [],
+      STRBEFORE: [],
+      STRAFTER: [],
+      YEAR: [],
+      MONTH: [],
+      DAY: [],
+      HOURS: [],
+      MINUTES: [],
+      SECONDS: [],
+      TIMEZONE: [],
+      TZ: [],
+      NOW: [],
+      UUID: [],
+      STRUUID: [],
+      MD5: [],
+      SHA1: [],
+      SHA256: [],
+      SHA384: [],
+      SHA512: [],
+      COALESCE: [],
+      IF: [],
+      STRLANG: [],
+      STRDT: [],
+      SAMETERM: [],
+      ISIRI: [],
+      ISURI: [],
+      ISBLANK: [],
+      ISLITERAL: [],
+      ISNUMERIC: [],
+      TRIPLE: [],
+      SUBJECT: [],
+      PREDICATE: [],
+      OBJECT: [],
+      isTRIPLE: [],
+      TRUE: [],
+      FALSE: [],
+      "<<": [],
+      COUNT: [],
+      SUM: [],
+      MIN: [],
+      MAX: [],
+      AVG: [],
+      SAMPLE: [],
+      GROUP_CONCAT: [],
+      SUBSTR: [],
+      REPLACE: [],
+      REGEX: [],
+      EXISTS: [],
+      IRI_REF: [],
+      STRING_LITERAL1: [],
+      STRING_LITERAL2: [],
+      STRING_LITERAL_LONG1: [],
+      STRING_LITERAL_LONG2: [],
+      INTEGER: [],
+      DECIMAL: [],
+      DOUBLE: [],
+      PNAME_LN: [],
+      PNAME_NS: [],
+      ";": [],
     },
     "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])": {
       "+": [
         "or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       "-": [
         "or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       INTEGER_POSITIVE: [
         "or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       DECIMAL_POSITIVE: [
         "or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       DOUBLE_POSITIVE: [
         "or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       INTEGER_NEGATIVE: [
         "or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       DECIMAL_NEGATIVE: [
         "or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       DOUBLE_NEGATIVE: [
         "or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       AS: [],
       ")": [],
@@ -501,7 +785,97 @@ module.exports = {
       ">=": [],
       IN: [],
       NOT: [],
-      ";": []
+      "!": [],
+      "+": [],
+      "-": [],
+      VAR1: [],
+      VAR2: [],
+      "(": [],
+      STR: [],
+      LANG: [],
+      LANGMATCHES: [],
+      DATATYPE: [],
+      BOUND: [],
+      IRI: [],
+      URI: [],
+      BNODE: [],
+      RAND: [],
+      ABS: [],
+      CEIL: [],
+      FLOOR: [],
+      ROUND: [],
+      CONCAT: [],
+      STRLEN: [],
+      UCASE: [],
+      LCASE: [],
+      ENCODE_FOR_URI: [],
+      CONTAINS: [],
+      STRSTARTS: [],
+      STRENDS: [],
+      STRBEFORE: [],
+      STRAFTER: [],
+      YEAR: [],
+      MONTH: [],
+      DAY: [],
+      HOURS: [],
+      MINUTES: [],
+      SECONDS: [],
+      TIMEZONE: [],
+      TZ: [],
+      NOW: [],
+      UUID: [],
+      STRUUID: [],
+      MD5: [],
+      SHA1: [],
+      SHA256: [],
+      SHA384: [],
+      SHA512: [],
+      COALESCE: [],
+      IF: [],
+      STRLANG: [],
+      STRDT: [],
+      SAMETERM: [],
+      ISIRI: [],
+      ISURI: [],
+      ISBLANK: [],
+      ISLITERAL: [],
+      ISNUMERIC: [],
+      TRIPLE: [],
+      SUBJECT: [],
+      PREDICATE: [],
+      OBJECT: [],
+      isTRIPLE: [],
+      TRUE: [],
+      FALSE: [],
+      "<<": [],
+      COUNT: [],
+      SUM: [],
+      MIN: [],
+      MAX: [],
+      AVG: [],
+      SAMPLE: [],
+      GROUP_CONCAT: [],
+      SUBSTR: [],
+      REPLACE: [],
+      REGEX: [],
+      EXISTS: [],
+      IRI_REF: [],
+      STRING_LITERAL1: [],
+      STRING_LITERAL2: [],
+      STRING_LITERAL_LONG1: [],
+      STRING_LITERAL_LONG2: [],
+      INTEGER: [],
+      DECIMAL: [],
+      DOUBLE: [],
+      INTEGER_POSITIVE: [],
+      DECIMAL_POSITIVE: [],
+      DOUBLE_POSITIVE: [],
+      INTEGER_NEGATIVE: [],
+      DECIMAL_NEGATIVE: [],
+      DOUBLE_NEGATIVE: [],
+      PNAME_LN: [],
+      PNAME_NS: [],
+      ";": [],
     },
     "*or([baseDecl,prefixDecl])": {
       BASE: ["or([baseDecl,prefixDecl])", "*or([baseDecl,prefixDecl])"],
@@ -520,7 +894,7 @@ module.exports = {
       MOVE: [],
       COPY: [],
       CREATE: [],
-      WITH: []
+      WITH: [],
     },
     "*or([var,[(,expression,AS,var,)]])": {
       "(": ["or([var,[(,expression,AS,var,)]])", "*or([var,[(,expression,AS,var,)]])"],
@@ -528,7 +902,7 @@ module.exports = {
       VAR2: ["or([var,[(,expression,AS,var,)]])", "*or([var,[(,expression,AS,var,)]])"],
       WHERE: [],
       "{": [],
-      FROM: []
+      FROM: [],
     },
     "*orderCondition": {
       ASC: ["orderCondition", "*orderCondition"],
@@ -585,6 +959,11 @@ module.exports = {
       ISBLANK: ["orderCondition", "*orderCondition"],
       ISLITERAL: ["orderCondition", "*orderCondition"],
       ISNUMERIC: ["orderCondition", "*orderCondition"],
+      TRIPLE: ["orderCondition", "*orderCondition"],
+      SUBJECT: ["orderCondition", "*orderCondition"],
+      PREDICATE: ["orderCondition", "*orderCondition"],
+      OBJECT: ["orderCondition", "*orderCondition"],
+      isTRIPLE: ["orderCondition", "*orderCondition"],
       SUBSTR: ["orderCondition", "*orderCondition"],
       REPLACE: ["orderCondition", "*orderCondition"],
       REGEX: ["orderCondition", "*orderCondition"],
@@ -597,16 +976,16 @@ module.exports = {
       LIMIT: [],
       OFFSET: [],
       $: [],
-      "}": []
+      "}": [],
     },
     "*usingClause": {
       USING: ["usingClause", "*usingClause"],
-      WHERE: []
+      WHERE: [],
     },
     "*var": {
       VAR1: ["var", "*var"],
       VAR2: ["var", "*var"],
-      ")": []
+      ")": [],
     },
     "*varOrIRIref": {
       VAR1: ["varOrIRIref", "*varOrIRIref"],
@@ -623,14 +1002,15 @@ module.exports = {
       "{": [],
       FROM: [],
       VALUES: [],
-      $: []
+      $: [],
     },
     "+graphNode": {
-      "(": ["graphNode", "*graphNode"],
-      "[": ["graphNode", "*graphNode"],
       VAR1: ["graphNode", "*graphNode"],
       VAR2: ["graphNode", "*graphNode"],
       NIL: ["graphNode", "*graphNode"],
+      "<<": ["graphNode", "*graphNode"],
+      "(": ["graphNode", "*graphNode"],
+      "[": ["graphNode", "*graphNode"],
       IRI_REF: ["graphNode", "*graphNode"],
       TRUE: ["graphNode", "*graphNode"],
       FALSE: ["graphNode", "*graphNode"],
@@ -650,14 +1030,15 @@ module.exports = {
       DOUBLE_POSITIVE: ["graphNode", "*graphNode"],
       INTEGER_NEGATIVE: ["graphNode", "*graphNode"],
       DECIMAL_NEGATIVE: ["graphNode", "*graphNode"],
-      DOUBLE_NEGATIVE: ["graphNode", "*graphNode"]
+      DOUBLE_NEGATIVE: ["graphNode", "*graphNode"],
     },
     "+graphNodePath": {
-      "(": ["graphNodePath", "*graphNodePath"],
-      "[": ["graphNodePath", "*graphNodePath"],
       VAR1: ["graphNodePath", "*graphNodePath"],
       VAR2: ["graphNodePath", "*graphNodePath"],
       NIL: ["graphNodePath", "*graphNodePath"],
+      "<<": ["graphNodePath", "*graphNodePath"],
+      "(": ["graphNodePath", "*graphNodePath"],
+      "[": ["graphNodePath", "*graphNodePath"],
       IRI_REF: ["graphNodePath", "*graphNodePath"],
       TRUE: ["graphNodePath", "*graphNodePath"],
       FALSE: ["graphNodePath", "*graphNodePath"],
@@ -677,7 +1058,7 @@ module.exports = {
       DOUBLE_POSITIVE: ["graphNodePath", "*graphNodePath"],
       INTEGER_NEGATIVE: ["graphNodePath", "*graphNodePath"],
       DECIMAL_NEGATIVE: ["graphNodePath", "*graphNodePath"],
-      DOUBLE_NEGATIVE: ["graphNodePath", "*graphNodePath"]
+      DOUBLE_NEGATIVE: ["graphNodePath", "*graphNodePath"],
     },
     "+groupCondition": {
       "(": ["groupCondition", "*groupCondition"],
@@ -730,6 +1111,11 @@ module.exports = {
       ISBLANK: ["groupCondition", "*groupCondition"],
       ISLITERAL: ["groupCondition", "*groupCondition"],
       ISNUMERIC: ["groupCondition", "*groupCondition"],
+      TRIPLE: ["groupCondition", "*groupCondition"],
+      SUBJECT: ["groupCondition", "*groupCondition"],
+      PREDICATE: ["groupCondition", "*groupCondition"],
+      OBJECT: ["groupCondition", "*groupCondition"],
+      isTRIPLE: ["groupCondition", "*groupCondition"],
       VAR1: ["groupCondition", "*groupCondition"],
       VAR2: ["groupCondition", "*groupCondition"],
       SUBSTR: ["groupCondition", "*groupCondition"],
@@ -739,7 +1125,7 @@ module.exports = {
       NOT: ["groupCondition", "*groupCondition"],
       IRI_REF: ["groupCondition", "*groupCondition"],
       PNAME_LN: ["groupCondition", "*groupCondition"],
-      PNAME_NS: ["groupCondition", "*groupCondition"]
+      PNAME_NS: ["groupCondition", "*groupCondition"],
     },
     "+havingCondition": {
       "(": ["havingCondition", "*havingCondition"],
@@ -792,6 +1178,11 @@ module.exports = {
       ISBLANK: ["havingCondition", "*havingCondition"],
       ISLITERAL: ["havingCondition", "*havingCondition"],
       ISNUMERIC: ["havingCondition", "*havingCondition"],
+      TRIPLE: ["havingCondition", "*havingCondition"],
+      SUBJECT: ["havingCondition", "*havingCondition"],
+      PREDICATE: ["havingCondition", "*havingCondition"],
+      OBJECT: ["havingCondition", "*havingCondition"],
+      isTRIPLE: ["havingCondition", "*havingCondition"],
       SUBSTR: ["havingCondition", "*havingCondition"],
       REPLACE: ["havingCondition", "*havingCondition"],
       REGEX: ["havingCondition", "*havingCondition"],
@@ -799,12 +1190,12 @@ module.exports = {
       NOT: ["havingCondition", "*havingCondition"],
       IRI_REF: ["havingCondition", "*havingCondition"],
       PNAME_LN: ["havingCondition", "*havingCondition"],
-      PNAME_NS: ["havingCondition", "*havingCondition"]
+      PNAME_NS: ["havingCondition", "*havingCondition"],
     },
     "+or([var,[(,expression,AS,var,)]])": {
       "(": ["or([var,[(,expression,AS,var,)]])", "*or([var,[(,expression,AS,var,)]])"],
       VAR1: ["or([var,[(,expression,AS,var,)]])", "*or([var,[(,expression,AS,var,)]])"],
-      VAR2: ["or([var,[(,expression,AS,var,)]])", "*or([var,[(,expression,AS,var,)]])"]
+      VAR2: ["or([var,[(,expression,AS,var,)]])", "*or([var,[(,expression,AS,var,)]])"],
     },
     "+orderCondition": {
       ASC: ["orderCondition", "*orderCondition"],
@@ -861,6 +1252,11 @@ module.exports = {
       ISBLANK: ["orderCondition", "*orderCondition"],
       ISLITERAL: ["orderCondition", "*orderCondition"],
       ISNUMERIC: ["orderCondition", "*orderCondition"],
+      TRIPLE: ["orderCondition", "*orderCondition"],
+      SUBJECT: ["orderCondition", "*orderCondition"],
+      PREDICATE: ["orderCondition", "*orderCondition"],
+      OBJECT: ["orderCondition", "*orderCondition"],
+      isTRIPLE: ["orderCondition", "*orderCondition"],
       SUBSTR: ["orderCondition", "*orderCondition"],
       REPLACE: ["orderCondition", "*orderCondition"],
       REGEX: ["orderCondition", "*orderCondition"],
@@ -868,27 +1264,28 @@ module.exports = {
       NOT: ["orderCondition", "*orderCondition"],
       IRI_REF: ["orderCondition", "*orderCondition"],
       PNAME_LN: ["orderCondition", "*orderCondition"],
-      PNAME_NS: ["orderCondition", "*orderCondition"]
+      PNAME_NS: ["orderCondition", "*orderCondition"],
     },
     "+varOrIRIref": {
       VAR1: ["varOrIRIref", "*varOrIRIref"],
       VAR2: ["varOrIRIref", "*varOrIRIref"],
       IRI_REF: ["varOrIRIref", "*varOrIRIref"],
       PNAME_LN: ["varOrIRIref", "*varOrIRIref"],
-      PNAME_NS: ["varOrIRIref", "*varOrIRIref"]
+      PNAME_NS: ["varOrIRIref", "*varOrIRIref"],
     },
     "?.": {
       ".": ["."],
       VAR1: [],
       VAR2: [],
       NIL: [],
-      "(": [],
-      "[": [],
+      "<<": [],
       IRI_REF: [],
       TRUE: [],
       FALSE: [],
       BLANK_NODE_LABEL: [],
       ANON: [],
+      "(": [],
+      "[": [],
       PNAME_LN: [],
       PNAME_NS: [],
       STRING_LITERAL1: [],
@@ -912,7 +1309,7 @@ module.exports = {
       FILTER: [],
       BIND: [],
       VALUES: [],
-      "}": []
+      "}": [],
     },
     "?DISTINCT": {
       DISTINCT: ["DISTINCT"],
@@ -971,8 +1368,14 @@ module.exports = {
       ISBLANK: [],
       ISLITERAL: [],
       ISNUMERIC: [],
+      TRIPLE: [],
+      SUBJECT: [],
+      PREDICATE: [],
+      OBJECT: [],
+      isTRIPLE: [],
       TRUE: [],
       FALSE: [],
+      "<<": [],
       COUNT: [],
       SUM: [],
       MIN: [],
@@ -1001,13 +1404,13 @@ module.exports = {
       DOUBLE_NEGATIVE: [],
       PNAME_LN: [],
       PNAME_NS: [],
-      "*": []
+      "*": [],
     },
     "?GRAPH": {
       GRAPH: ["GRAPH"],
       IRI_REF: [],
       PNAME_LN: [],
-      PNAME_NS: []
+      PNAME_NS: [],
     },
     "?SILENT": {
       SILENT: ["SILENT"],
@@ -1015,24 +1418,24 @@ module.exports = {
       VAR2: [],
       IRI_REF: [],
       PNAME_LN: [],
-      PNAME_NS: []
+      PNAME_NS: [],
     },
     "?SILENT_1": {
       SILENT: ["SILENT"],
       IRI_REF: [],
       PNAME_LN: [],
-      PNAME_NS: []
+      PNAME_NS: [],
     },
     "?SILENT_2": {
       SILENT: ["SILENT"],
       GRAPH: [],
       DEFAULT: [],
       NAMED: [],
-      ALL: []
+      ALL: [],
     },
     "?SILENT_3": {
       SILENT: ["SILENT"],
-      GRAPH: []
+      GRAPH: [],
     },
     "?SILENT_4": {
       SILENT: ["SILENT"],
@@ -1040,19 +1443,19 @@ module.exports = {
       GRAPH: [],
       IRI_REF: [],
       PNAME_LN: [],
-      PNAME_NS: []
+      PNAME_NS: [],
     },
     "?WHERE": {
       WHERE: ["WHERE"],
-      "{": []
+      "{": [],
     },
     "?[,,expression]": {
       ",": ["[,,expression]"],
-      ")": []
+      ")": [],
     },
     "?[.,?constructTriples]": {
       ".": ["[.,?constructTriples]"],
-      "}": []
+      "}": [],
     },
     "?[.,?triplesBlock]": {
       ".": ["[.,?triplesBlock]"],
@@ -1064,29 +1467,29 @@ module.exports = {
       FILTER: [],
       BIND: [],
       VALUES: [],
-      "}": []
+      "}": [],
     },
     "?[.,?triplesTemplate]": {
       ".": ["[.,?triplesTemplate]"],
       "}": [],
-      GRAPH: []
+      GRAPH: [],
     },
     "?[;,SEPARATOR,=,string]": {
       ";": ["[;,SEPARATOR,=,string]"],
-      ")": []
+      ")": [],
     },
     "?[;,update]": {
       ";": ["[;,update]"],
-      $: []
+      $: [],
     },
     "?[AS,var]": {
       AS: ["[AS,var]"],
-      ")": []
+      ")": [],
     },
     "?[INTO,graphRef]": {
       INTO: ["[INTO,graphRef]"],
       ";": [],
-      $: []
+      $: [],
     },
     "?[or([verbPath,verbSimple]),objectListPath]": {
       VAR1: ["[or([verbPath,verbSimple]),objectListPath]"],
@@ -1101,6 +1504,7 @@ module.exports = {
       ";": [],
       ".": [],
       "]": [],
+      "|}": [],
       "{": [],
       OPTIONAL: [],
       MINUS: [],
@@ -1109,7 +1513,7 @@ module.exports = {
       FILTER: [],
       BIND: [],
       VALUES: [],
-      "}": []
+      "}": [],
     },
     "?[pathOneInPropertySet,*[|,pathOneInPropertySet]]": {
       a: ["[pathOneInPropertySet,*[|,pathOneInPropertySet]]"],
@@ -1117,7 +1521,7 @@ module.exports = {
       IRI_REF: ["[pathOneInPropertySet,*[|,pathOneInPropertySet]]"],
       PNAME_LN: ["[pathOneInPropertySet,*[|,pathOneInPropertySet]]"],
       PNAME_NS: ["[pathOneInPropertySet,*[|,pathOneInPropertySet]]"],
-      ")": []
+      ")": [],
     },
     "?[update1,?[;,update]]": {
       INSERT: ["[update1,?[;,update]]"],
@@ -1130,7 +1534,7 @@ module.exports = {
       COPY: ["[update1,?[;,update]]"],
       CREATE: ["[update1,?[;,update]]"],
       WITH: ["[update1,?[;,update]]"],
-      $: []
+      $: [],
     },
     "?[verb,objectList]": {
       a: ["[verb,objectList]"],
@@ -1142,6 +1546,7 @@ module.exports = {
       ";": [],
       ".": [],
       "]": [],
+      "|}": [],
       "}": [],
       GRAPH: [],
       "{": [],
@@ -1150,7 +1555,41 @@ module.exports = {
       SERVICE: [],
       FILTER: [],
       BIND: [],
-      VALUES: []
+      VALUES: [],
+    },
+    "?annotationPattern": {
+      "{|": ["annotationPattern"],
+      ".": [],
+      ";": [],
+      ",": [],
+      "]": [],
+      "|}": [],
+      "}": [],
+      GRAPH: [],
+      "{": [],
+      OPTIONAL: [],
+      MINUS: [],
+      SERVICE: [],
+      FILTER: [],
+      BIND: [],
+      VALUES: [],
+    },
+    "?annotationPatternPath": {
+      "{|": ["annotationPatternPath"],
+      ".": [],
+      ";": [],
+      ",": [],
+      "]": [],
+      "|}": [],
+      "{": [],
+      OPTIONAL: [],
+      MINUS: [],
+      GRAPH: [],
+      SERVICE: [],
+      FILTER: [],
+      BIND: [],
+      VALUES: [],
+      "}": [],
     },
     "?argList": {
       NIL: ["argList"],
@@ -1178,19 +1617,102 @@ module.exports = {
       DOUBLE_NEGATIVE: [],
       "*": [],
       "/": [],
-      ";": []
+      "!": [],
+      VAR1: [],
+      VAR2: [],
+      "(": [],
+      STR: [],
+      LANG: [],
+      LANGMATCHES: [],
+      DATATYPE: [],
+      BOUND: [],
+      IRI: [],
+      URI: [],
+      BNODE: [],
+      RAND: [],
+      ABS: [],
+      CEIL: [],
+      FLOOR: [],
+      ROUND: [],
+      CONCAT: [],
+      STRLEN: [],
+      UCASE: [],
+      LCASE: [],
+      ENCODE_FOR_URI: [],
+      CONTAINS: [],
+      STRSTARTS: [],
+      STRENDS: [],
+      STRBEFORE: [],
+      STRAFTER: [],
+      YEAR: [],
+      MONTH: [],
+      DAY: [],
+      HOURS: [],
+      MINUTES: [],
+      SECONDS: [],
+      TIMEZONE: [],
+      TZ: [],
+      NOW: [],
+      UUID: [],
+      STRUUID: [],
+      MD5: [],
+      SHA1: [],
+      SHA256: [],
+      SHA384: [],
+      SHA512: [],
+      COALESCE: [],
+      IF: [],
+      STRLANG: [],
+      STRDT: [],
+      SAMETERM: [],
+      ISIRI: [],
+      ISURI: [],
+      ISBLANK: [],
+      ISLITERAL: [],
+      ISNUMERIC: [],
+      TRIPLE: [],
+      SUBJECT: [],
+      PREDICATE: [],
+      OBJECT: [],
+      isTRIPLE: [],
+      TRUE: [],
+      FALSE: [],
+      "<<": [],
+      COUNT: [],
+      SUM: [],
+      MIN: [],
+      MAX: [],
+      AVG: [],
+      SAMPLE: [],
+      GROUP_CONCAT: [],
+      SUBSTR: [],
+      REPLACE: [],
+      REGEX: [],
+      EXISTS: [],
+      IRI_REF: [],
+      STRING_LITERAL1: [],
+      STRING_LITERAL2: [],
+      STRING_LITERAL_LONG1: [],
+      STRING_LITERAL_LONG2: [],
+      INTEGER: [],
+      DECIMAL: [],
+      DOUBLE: [],
+      PNAME_LN: [],
+      PNAME_NS: [],
+      ";": [],
     },
     "?constructTriples": {
       VAR1: ["constructTriples"],
       VAR2: ["constructTriples"],
       NIL: ["constructTriples"],
-      "(": ["constructTriples"],
-      "[": ["constructTriples"],
+      "<<": ["constructTriples"],
       IRI_REF: ["constructTriples"],
       TRUE: ["constructTriples"],
       FALSE: ["constructTriples"],
       BLANK_NODE_LABEL: ["constructTriples"],
       ANON: ["constructTriples"],
+      "(": ["constructTriples"],
+      "[": ["constructTriples"],
       PNAME_LN: ["constructTriples"],
       PNAME_NS: ["constructTriples"],
       STRING_LITERAL1: ["constructTriples"],
@@ -1206,7 +1728,7 @@ module.exports = {
       INTEGER_NEGATIVE: ["constructTriples"],
       DECIMAL_NEGATIVE: ["constructTriples"],
       DOUBLE_NEGATIVE: ["constructTriples"],
-      "}": []
+      "}": [],
     },
     "?groupClause": {
       GROUP: ["groupClause"],
@@ -1216,7 +1738,7 @@ module.exports = {
       ORDER: [],
       HAVING: [],
       $: [],
-      "}": []
+      "}": [],
     },
     "?havingClause": {
       HAVING: ["havingClause"],
@@ -1225,31 +1747,31 @@ module.exports = {
       OFFSET: [],
       ORDER: [],
       $: [],
-      "}": []
+      "}": [],
     },
     "?insertClause": {
       INSERT: ["insertClause"],
       WHERE: [],
-      USING: []
+      USING: [],
     },
     "?limitClause": {
       LIMIT: ["limitClause"],
       VALUES: [],
       $: [],
-      "}": []
+      "}": [],
     },
     "?limitOffsetClauses": {
       LIMIT: ["limitOffsetClauses"],
       OFFSET: ["limitOffsetClauses"],
       VALUES: [],
       $: [],
-      "}": []
+      "}": [],
     },
     "?offsetClause": {
       OFFSET: ["offsetClause"],
       VALUES: [],
       $: [],
-      "}": []
+      "}": [],
     },
     "?or([DISTINCT,REDUCED])": {
       DISTINCT: ["or([DISTINCT,REDUCED])"],
@@ -1257,12 +1779,13 @@ module.exports = {
       "*": [],
       "(": [],
       VAR1: [],
-      VAR2: []
+      VAR2: [],
     },
     "?or([LANGTAG,[^^,iriRef]])": {
       LANGTAG: ["or([LANGTAG,[^^,iriRef]])"],
       "^^": ["or([LANGTAG,[^^,iriRef]])"],
       UNDEF: [],
+      "<<": [],
       IRI_REF: [],
       TRUE: [],
       FALSE: [],
@@ -1281,17 +1804,9 @@ module.exports = {
       INTEGER_NEGATIVE: [],
       DECIMAL_NEGATIVE: [],
       DOUBLE_NEGATIVE: [],
-      a: [],
-      VAR1: [],
-      VAR2: [],
-      "^": [],
-      "!": [],
-      "(": [],
-      ".": [],
-      ";": [],
-      ",": [],
       AS: [],
       ")": [],
+      ",": [],
       "||": [],
       "&&": [],
       "=": [],
@@ -1306,12 +1821,88 @@ module.exports = {
       "-": [],
       "*": [],
       "/": [],
+      a: [],
+      ">>": [],
+      VAR1: [],
+      VAR2: [],
       "}": [],
-      "[": [],
+      "^": [],
+      "!": [],
+      "(": [],
+      ".": [],
+      ";": [],
+      "{|": [],
+      STR: [],
+      LANG: [],
+      LANGMATCHES: [],
+      DATATYPE: [],
+      BOUND: [],
+      IRI: [],
+      URI: [],
+      BNODE: [],
+      RAND: [],
+      ABS: [],
+      CEIL: [],
+      FLOOR: [],
+      ROUND: [],
+      CONCAT: [],
+      STRLEN: [],
+      UCASE: [],
+      LCASE: [],
+      ENCODE_FOR_URI: [],
+      CONTAINS: [],
+      STRSTARTS: [],
+      STRENDS: [],
+      STRBEFORE: [],
+      STRAFTER: [],
+      YEAR: [],
+      MONTH: [],
+      DAY: [],
+      HOURS: [],
+      MINUTES: [],
+      SECONDS: [],
+      TIMEZONE: [],
+      TZ: [],
+      NOW: [],
+      UUID: [],
+      STRUUID: [],
+      MD5: [],
+      SHA1: [],
+      SHA256: [],
+      SHA384: [],
+      SHA512: [],
+      COALESCE: [],
+      IF: [],
+      STRLANG: [],
+      STRDT: [],
+      SAMETERM: [],
+      ISIRI: [],
+      ISURI: [],
+      ISBLANK: [],
+      ISLITERAL: [],
+      ISNUMERIC: [],
+      TRIPLE: [],
+      SUBJECT: [],
+      PREDICATE: [],
+      OBJECT: [],
+      isTRIPLE: [],
+      COUNT: [],
+      SUM: [],
+      MIN: [],
+      MAX: [],
+      AVG: [],
+      SAMPLE: [],
+      GROUP_CONCAT: [],
+      SUBSTR: [],
+      REPLACE: [],
+      REGEX: [],
+      EXISTS: [],
       NIL: [],
+      "[": [],
       BLANK_NODE_LABEL: [],
       ANON: [],
       "]": [],
+      "|}": [],
       GRAPH: [],
       "{": [],
       OPTIONAL: [],
@@ -1319,7 +1910,7 @@ module.exports = {
       SERVICE: [],
       FILTER: [],
       BIND: [],
-      VALUES: []
+      VALUES: [],
     },
     "?or([[*,unaryExpression],[/,unaryExpression]])": {
       "*": ["or([[*,unaryExpression],[/,unaryExpression]])"],
@@ -1345,39 +1936,212 @@ module.exports = {
       ">=": [],
       IN: [],
       NOT: [],
-      ";": []
+      "!": [],
+      VAR1: [],
+      VAR2: [],
+      "(": [],
+      STR: [],
+      LANG: [],
+      LANGMATCHES: [],
+      DATATYPE: [],
+      BOUND: [],
+      IRI: [],
+      URI: [],
+      BNODE: [],
+      RAND: [],
+      ABS: [],
+      CEIL: [],
+      FLOOR: [],
+      ROUND: [],
+      CONCAT: [],
+      STRLEN: [],
+      UCASE: [],
+      LCASE: [],
+      ENCODE_FOR_URI: [],
+      CONTAINS: [],
+      STRSTARTS: [],
+      STRENDS: [],
+      STRBEFORE: [],
+      STRAFTER: [],
+      YEAR: [],
+      MONTH: [],
+      DAY: [],
+      HOURS: [],
+      MINUTES: [],
+      SECONDS: [],
+      TIMEZONE: [],
+      TZ: [],
+      NOW: [],
+      UUID: [],
+      STRUUID: [],
+      MD5: [],
+      SHA1: [],
+      SHA256: [],
+      SHA384: [],
+      SHA512: [],
+      COALESCE: [],
+      IF: [],
+      STRLANG: [],
+      STRDT: [],
+      SAMETERM: [],
+      ISIRI: [],
+      ISURI: [],
+      ISBLANK: [],
+      ISLITERAL: [],
+      ISNUMERIC: [],
+      TRIPLE: [],
+      SUBJECT: [],
+      PREDICATE: [],
+      OBJECT: [],
+      isTRIPLE: [],
+      TRUE: [],
+      FALSE: [],
+      "<<": [],
+      COUNT: [],
+      SUM: [],
+      MIN: [],
+      MAX: [],
+      AVG: [],
+      SAMPLE: [],
+      GROUP_CONCAT: [],
+      SUBSTR: [],
+      REPLACE: [],
+      REGEX: [],
+      EXISTS: [],
+      IRI_REF: [],
+      STRING_LITERAL1: [],
+      STRING_LITERAL2: [],
+      STRING_LITERAL_LONG1: [],
+      STRING_LITERAL_LONG2: [],
+      INTEGER: [],
+      DECIMAL: [],
+      DOUBLE: [],
+      PNAME_LN: [],
+      PNAME_NS: [],
+      ";": [],
     },
     "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])": {
       "=": [
-        "or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       "!=": [
-        "or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       "<": [
-        "or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       ">": [
-        "or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       "<=": [
-        "or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       ">=": [
-        "or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       IN: [
-        "or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       NOT: [
-        "or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       AS: [],
       ")": [],
       ",": [],
       "||": [],
       "&&": [],
-      ";": []
+      "!": [],
+      "+": [],
+      "-": [],
+      VAR1: [],
+      VAR2: [],
+      "(": [],
+      STR: [],
+      LANG: [],
+      LANGMATCHES: [],
+      DATATYPE: [],
+      BOUND: [],
+      IRI: [],
+      URI: [],
+      BNODE: [],
+      RAND: [],
+      ABS: [],
+      CEIL: [],
+      FLOOR: [],
+      ROUND: [],
+      CONCAT: [],
+      STRLEN: [],
+      UCASE: [],
+      LCASE: [],
+      ENCODE_FOR_URI: [],
+      CONTAINS: [],
+      STRSTARTS: [],
+      STRENDS: [],
+      STRBEFORE: [],
+      STRAFTER: [],
+      YEAR: [],
+      MONTH: [],
+      DAY: [],
+      HOURS: [],
+      MINUTES: [],
+      SECONDS: [],
+      TIMEZONE: [],
+      TZ: [],
+      NOW: [],
+      UUID: [],
+      STRUUID: [],
+      MD5: [],
+      SHA1: [],
+      SHA256: [],
+      SHA384: [],
+      SHA512: [],
+      COALESCE: [],
+      IF: [],
+      STRLANG: [],
+      STRDT: [],
+      SAMETERM: [],
+      ISIRI: [],
+      ISURI: [],
+      ISBLANK: [],
+      ISLITERAL: [],
+      ISNUMERIC: [],
+      TRIPLE: [],
+      SUBJECT: [],
+      PREDICATE: [],
+      OBJECT: [],
+      isTRIPLE: [],
+      TRUE: [],
+      FALSE: [],
+      "<<": [],
+      COUNT: [],
+      SUM: [],
+      MIN: [],
+      MAX: [],
+      AVG: [],
+      SAMPLE: [],
+      GROUP_CONCAT: [],
+      SUBSTR: [],
+      REPLACE: [],
+      REGEX: [],
+      EXISTS: [],
+      NOT: [],
+      IRI_REF: [],
+      STRING_LITERAL1: [],
+      STRING_LITERAL2: [],
+      STRING_LITERAL_LONG1: [],
+      STRING_LITERAL_LONG2: [],
+      INTEGER: [],
+      DECIMAL: [],
+      DOUBLE: [],
+      INTEGER_POSITIVE: [],
+      DECIMAL_POSITIVE: [],
+      DOUBLE_POSITIVE: [],
+      INTEGER_NEGATIVE: [],
+      DECIMAL_NEGATIVE: [],
+      DOUBLE_NEGATIVE: [],
+      PNAME_LN: [],
+      PNAME_NS: [],
+      ";": [],
     },
     "?orderClause": {
       ORDER: ["orderClause"],
@@ -1385,7 +2149,7 @@ module.exports = {
       LIMIT: [],
       OFFSET: [],
       $: [],
-      "}": []
+      "}": [],
     },
     "?pathMod": {
       "*": ["pathMod"],
@@ -1395,11 +2159,12 @@ module.exports = {
       "|": [],
       "/": [],
       ")": [],
-      "(": [],
-      "[": [],
       VAR1: [],
       VAR2: [],
       NIL: [],
+      "<<": [],
+      "(": [],
+      "[": [],
       IRI_REF: [],
       TRUE: [],
       FALSE: [],
@@ -1419,19 +2184,20 @@ module.exports = {
       DOUBLE_POSITIVE: [],
       INTEGER_NEGATIVE: [],
       DECIMAL_NEGATIVE: [],
-      DOUBLE_NEGATIVE: []
+      DOUBLE_NEGATIVE: [],
     },
     "?triplesBlock": {
       VAR1: ["triplesBlock"],
       VAR2: ["triplesBlock"],
       NIL: ["triplesBlock"],
-      "(": ["triplesBlock"],
-      "[": ["triplesBlock"],
+      "<<": ["triplesBlock"],
       IRI_REF: ["triplesBlock"],
       TRUE: ["triplesBlock"],
       FALSE: ["triplesBlock"],
       BLANK_NODE_LABEL: ["triplesBlock"],
       ANON: ["triplesBlock"],
+      "(": ["triplesBlock"],
+      "[": ["triplesBlock"],
       PNAME_LN: ["triplesBlock"],
       PNAME_NS: ["triplesBlock"],
       STRING_LITERAL1: ["triplesBlock"],
@@ -1455,19 +2221,20 @@ module.exports = {
       FILTER: [],
       BIND: [],
       VALUES: [],
-      "}": []
+      "}": [],
     },
     "?triplesTemplate": {
       VAR1: ["triplesTemplate"],
       VAR2: ["triplesTemplate"],
       NIL: ["triplesTemplate"],
-      "(": ["triplesTemplate"],
-      "[": ["triplesTemplate"],
+      "<<": ["triplesTemplate"],
       IRI_REF: ["triplesTemplate"],
       TRUE: ["triplesTemplate"],
       FALSE: ["triplesTemplate"],
       BLANK_NODE_LABEL: ["triplesTemplate"],
       ANON: ["triplesTemplate"],
+      "(": ["triplesTemplate"],
+      "[": ["triplesTemplate"],
       PNAME_LN: ["triplesTemplate"],
       PNAME_NS: ["triplesTemplate"],
       STRING_LITERAL1: ["triplesTemplate"],
@@ -1484,7 +2251,7 @@ module.exports = {
       DECIMAL_NEGATIVE: ["triplesTemplate"],
       DOUBLE_NEGATIVE: ["triplesTemplate"],
       "}": [],
-      GRAPH: []
+      GRAPH: [],
     },
     "?whereClause": {
       WHERE: ["whereClause"],
@@ -1495,122 +2262,122 @@ module.exports = {
       LIMIT: [],
       OFFSET: [],
       VALUES: [],
-      $: []
+      $: [],
     },
     "[!=,numericExpression]": {
-      "!=": ["!=", "numericExpression"]
+      "!=": ["!=", "numericExpression"],
     },
     "[&&,valueLogical]": {
-      "&&": ["&&", "valueLogical"]
+      "&&": ["&&", "valueLogical"],
     },
     "[(,*dataBlockValue,)]": {
-      "(": ["(", "*dataBlockValue", ")"]
+      "(": ["(", "*dataBlockValue", ")"],
     },
     "[(,*var,)]": {
-      "(": ["(", "*var", ")"]
+      "(": ["(", "*var", ")"],
     },
     "[(,expression,)]": {
-      "(": ["(", "expression", ")"]
+      "(": ["(", "expression", ")"],
     },
     "[(,expression,AS,var,)]": {
-      "(": ["(", "expression", "AS", "var", ")"]
+      "(": ["(", "expression", "AS", "var", ")"],
     },
     "[*,unaryExpression]": {
-      "*": ["*", "unaryExpression"]
+      "*": ["*", "unaryExpression"],
     },
     "[*datasetClause,WHERE,{,?triplesTemplate,},solutionModifier]": {
       WHERE: ["*datasetClause", "WHERE", "{", "?triplesTemplate", "}", "solutionModifier"],
-      FROM: ["*datasetClause", "WHERE", "{", "?triplesTemplate", "}", "solutionModifier"]
+      FROM: ["*datasetClause", "WHERE", "{", "?triplesTemplate", "}", "solutionModifier"],
     },
     "[+,multiplicativeExpression]": {
-      "+": ["+", "multiplicativeExpression"]
+      "+": ["+", "multiplicativeExpression"],
     },
     "[,,expression]": {
-      ",": [",", "expression"]
+      ",": [",", "expression"],
     },
     "[,,integer,}]": {
-      ",": [",", "integer", "}"]
+      ",": [",", "integer", "}"],
     },
     "[,,objectPath]": {
-      ",": [",", "objectPath"]
+      ",": [",", "objectPath"],
     },
     "[,,object]": {
-      ",": [",", "object"]
+      ",": [",", "object"],
     },
     "[,,or([},[integer,}]])]": {
-      ",": [",", "or([},[integer,}]])"]
+      ",": [",", "or([},[integer,}]])"],
     },
     "[-,multiplicativeExpression]": {
-      "-": ["-", "multiplicativeExpression"]
+      "-": ["-", "multiplicativeExpression"],
     },
     "[.,?constructTriples]": {
-      ".": [".", "?constructTriples"]
+      ".": [".", "?constructTriples"],
     },
     "[.,?triplesBlock]": {
-      ".": [".", "?triplesBlock"]
+      ".": [".", "?triplesBlock"],
     },
     "[.,?triplesTemplate]": {
-      ".": [".", "?triplesTemplate"]
+      ".": [".", "?triplesTemplate"],
     },
     "[/,pathEltOrInverse]": {
-      "/": ["/", "pathEltOrInverse"]
+      "/": ["/", "pathEltOrInverse"],
     },
     "[/,unaryExpression]": {
-      "/": ["/", "unaryExpression"]
+      "/": ["/", "unaryExpression"],
     },
     "[;,?[or([verbPath,verbSimple]),objectListPath]]": {
-      ";": [";", "?[or([verbPath,verbSimple]),objectListPath]"]
+      ";": [";", "?[or([verbPath,verbSimple]),objectListPath]"],
     },
     "[;,?[verb,objectList]]": {
-      ";": [";", "?[verb,objectList]"]
+      ";": [";", "?[verb,objectList]"],
     },
     "[;,SEPARATOR,=,string]": {
-      ";": [";", "SEPARATOR", "=", "string"]
+      ";": [";", "SEPARATOR", "=", "string"],
     },
     "[;,update]": {
-      ";": [";", "update"]
+      ";": [";", "update"],
     },
     "[<,numericExpression]": {
-      "<": ["<", "numericExpression"]
+      "<": ["<", "numericExpression"],
     },
     "[<=,numericExpression]": {
-      "<=": ["<=", "numericExpression"]
+      "<=": ["<=", "numericExpression"],
     },
     "[=,numericExpression]": {
-      "=": ["=", "numericExpression"]
+      "=": ["=", "numericExpression"],
     },
     "[>,numericExpression]": {
-      ">": [">", "numericExpression"]
+      ">": [">", "numericExpression"],
     },
     "[>=,numericExpression]": {
-      ">=": [">=", "numericExpression"]
+      ">=": [">=", "numericExpression"],
     },
     "[AS,var]": {
-      AS: ["AS", "var"]
+      AS: ["AS", "var"],
     },
     "[IN,expressionList]": {
-      IN: ["IN", "expressionList"]
+      IN: ["IN", "expressionList"],
     },
     "[INTO,graphRef]": {
-      INTO: ["INTO", "graphRef"]
+      INTO: ["INTO", "graphRef"],
     },
     "[NAMED,iriRef]": {
-      NAMED: ["NAMED", "iriRef"]
+      NAMED: ["NAMED", "iriRef"],
     },
     "[NOT,IN,expressionList]": {
-      NOT: ["NOT", "IN", "expressionList"]
+      NOT: ["NOT", "IN", "expressionList"],
     },
     "[UNION,groupGraphPattern]": {
-      UNION: ["UNION", "groupGraphPattern"]
+      UNION: ["UNION", "groupGraphPattern"],
     },
     "[^^,iriRef]": {
-      "^^": ["^^", "iriRef"]
+      "^^": ["^^", "iriRef"],
     },
     "[constructTemplate,*datasetClause,whereClause,solutionModifier]": {
-      "{": ["constructTemplate", "*datasetClause", "whereClause", "solutionModifier"]
+      "{": ["constructTemplate", "*datasetClause", "whereClause", "solutionModifier"],
     },
     "[deleteClause,?insertClause]": {
-      DELETE: ["deleteClause", "?insertClause"]
+      DELETE: ["deleteClause", "?insertClause"],
     },
     "[graphPatternNotTriples,?.,?triplesBlock]": {
       "{": ["graphPatternNotTriples", "?.", "?triplesBlock"],
@@ -1620,39 +2387,39 @@ module.exports = {
       SERVICE: ["graphPatternNotTriples", "?.", "?triplesBlock"],
       FILTER: ["graphPatternNotTriples", "?.", "?triplesBlock"],
       BIND: ["graphPatternNotTriples", "?.", "?triplesBlock"],
-      VALUES: ["graphPatternNotTriples", "?.", "?triplesBlock"]
+      VALUES: ["graphPatternNotTriples", "?.", "?triplesBlock"],
     },
     "[integer,or([[,,or([},[integer,}]])],}])]": {
-      INTEGER: ["integer", "or([[,,or([},[integer,}]])],}])"]
+      INTEGER: ["integer", "or([[,,or([},[integer,}]])],}])"],
     },
     "[integer,}]": {
-      INTEGER: ["integer", "}"]
+      INTEGER: ["integer", "}"],
     },
     "[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]": {
       INTEGER_POSITIVE: [
         "or([numericLiteralPositive,numericLiteralNegative])",
-        "?or([[*,unaryExpression],[/,unaryExpression]])"
+        "?or([[*,unaryExpression],[/,unaryExpression]])",
       ],
       DECIMAL_POSITIVE: [
         "or([numericLiteralPositive,numericLiteralNegative])",
-        "?or([[*,unaryExpression],[/,unaryExpression]])"
+        "?or([[*,unaryExpression],[/,unaryExpression]])",
       ],
       DOUBLE_POSITIVE: [
         "or([numericLiteralPositive,numericLiteralNegative])",
-        "?or([[*,unaryExpression],[/,unaryExpression]])"
+        "?or([[*,unaryExpression],[/,unaryExpression]])",
       ],
       INTEGER_NEGATIVE: [
         "or([numericLiteralPositive,numericLiteralNegative])",
-        "?or([[*,unaryExpression],[/,unaryExpression]])"
+        "?or([[*,unaryExpression],[/,unaryExpression]])",
       ],
       DECIMAL_NEGATIVE: [
         "or([numericLiteralPositive,numericLiteralNegative])",
-        "?or([[*,unaryExpression],[/,unaryExpression]])"
+        "?or([[*,unaryExpression],[/,unaryExpression]])",
       ],
       DOUBLE_NEGATIVE: [
         "or([numericLiteralPositive,numericLiteralNegative])",
-        "?or([[*,unaryExpression],[/,unaryExpression]])"
-      ]
+        "?or([[*,unaryExpression],[/,unaryExpression]])",
+      ],
     },
     "[or([verbPath,verbSimple]),objectListPath]": {
       VAR1: ["or([verbPath,verbSimple])", "objectListPath"],
@@ -1663,17 +2430,17 @@ module.exports = {
       "(": ["or([verbPath,verbSimple])", "objectListPath"],
       IRI_REF: ["or([verbPath,verbSimple])", "objectListPath"],
       PNAME_LN: ["or([verbPath,verbSimple])", "objectListPath"],
-      PNAME_NS: ["or([verbPath,verbSimple])", "objectListPath"]
+      PNAME_NS: ["or([verbPath,verbSimple])", "objectListPath"],
     },
     "[pathOneInPropertySet,*[|,pathOneInPropertySet]]": {
       a: ["pathOneInPropertySet", "*[|,pathOneInPropertySet]"],
       "^": ["pathOneInPropertySet", "*[|,pathOneInPropertySet]"],
       IRI_REF: ["pathOneInPropertySet", "*[|,pathOneInPropertySet]"],
       PNAME_LN: ["pathOneInPropertySet", "*[|,pathOneInPropertySet]"],
-      PNAME_NS: ["pathOneInPropertySet", "*[|,pathOneInPropertySet]"]
+      PNAME_NS: ["pathOneInPropertySet", "*[|,pathOneInPropertySet]"],
     },
     "[quadsNotTriples,?.,?triplesTemplate]": {
-      GRAPH: ["quadsNotTriples", "?.", "?triplesTemplate"]
+      GRAPH: ["quadsNotTriples", "?.", "?triplesTemplate"],
     },
     "[update1,?[;,update]]": {
       INSERT: ["update1", "?[;,update]"],
@@ -1685,7 +2452,7 @@ module.exports = {
       MOVE: ["update1", "?[;,update]"],
       COPY: ["update1", "?[;,update]"],
       CREATE: ["update1", "?[;,update]"],
-      WITH: ["update1", "?[;,update]"]
+      WITH: ["update1", "?[;,update]"],
     },
     "[verb,objectList]": {
       a: ["verb", "objectList"],
@@ -1693,361 +2460,385 @@ module.exports = {
       VAR2: ["verb", "objectList"],
       IRI_REF: ["verb", "objectList"],
       PNAME_LN: ["verb", "objectList"],
-      PNAME_NS: ["verb", "objectList"]
+      PNAME_NS: ["verb", "objectList"],
     },
     "[|,pathOneInPropertySet]": {
-      "|": ["|", "pathOneInPropertySet"]
+      "|": ["|", "pathOneInPropertySet"],
     },
     "[|,pathSequence]": {
-      "|": ["|", "pathSequence"]
+      "|": ["|", "pathSequence"],
     },
     "[||,conditionalAndExpression]": {
-      "||": ["||", "conditionalAndExpression"]
+      "||": ["||", "conditionalAndExpression"],
     },
     add: {
-      ADD: ["ADD", "?SILENT_4", "graphOrDefault", "TO", "graphOrDefault"]
+      ADD: ["ADD", "?SILENT_4", "graphOrDefault", "TO", "graphOrDefault"],
     },
     additiveExpression: {
       "!": [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       "+": [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       "-": [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       VAR1: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       VAR2: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       "(": [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       STR: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       LANG: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       LANGMATCHES: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       DATATYPE: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       BOUND: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       IRI: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       URI: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       BNODE: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       RAND: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       ABS: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       CEIL: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       FLOOR: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       ROUND: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       CONCAT: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       STRLEN: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       UCASE: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       LCASE: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       ENCODE_FOR_URI: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       CONTAINS: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       STRSTARTS: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       STRENDS: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       STRBEFORE: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       STRAFTER: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       YEAR: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       MONTH: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       DAY: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       HOURS: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       MINUTES: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       SECONDS: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       TIMEZONE: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       TZ: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       NOW: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       UUID: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       STRUUID: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       MD5: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       SHA1: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       SHA256: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       SHA384: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       SHA512: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       COALESCE: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       IF: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       STRLANG: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       STRDT: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       SAMETERM: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       ISIRI: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       ISURI: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       ISBLANK: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       ISLITERAL: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       ISNUMERIC: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
+      ],
+      TRIPLE: [
+        "multiplicativeExpression",
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
+      ],
+      SUBJECT: [
+        "multiplicativeExpression",
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
+      ],
+      PREDICATE: [
+        "multiplicativeExpression",
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
+      ],
+      OBJECT: [
+        "multiplicativeExpression",
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
+      ],
+      isTRIPLE: [
+        "multiplicativeExpression",
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       TRUE: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       FALSE: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
+      ],
+      "<<": [
+        "multiplicativeExpression",
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       COUNT: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       SUM: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       MIN: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       MAX: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       AVG: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       SAMPLE: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       GROUP_CONCAT: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       SUBSTR: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       REPLACE: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       REGEX: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       EXISTS: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       NOT: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       IRI_REF: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       STRING_LITERAL1: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       STRING_LITERAL2: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       STRING_LITERAL_LONG1: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       STRING_LITERAL_LONG2: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       INTEGER: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       DECIMAL: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       DOUBLE: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       INTEGER_POSITIVE: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       DECIMAL_POSITIVE: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       DOUBLE_POSITIVE: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       INTEGER_NEGATIVE: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       DECIMAL_NEGATIVE: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       DOUBLE_NEGATIVE: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       PNAME_LN: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
       ],
       PNAME_NS: [
         "multiplicativeExpression",
-        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])"
-      ]
+        "*or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])",
+      ],
     },
     aggregate: {
       COUNT: ["COUNT", "(", "?DISTINCT", "or([*,expression])", ")"],
@@ -2056,43 +2847,49 @@ module.exports = {
       MAX: ["MAX", "(", "?DISTINCT", "expression", ")"],
       AVG: ["AVG", "(", "?DISTINCT", "expression", ")"],
       SAMPLE: ["SAMPLE", "(", "?DISTINCT", "expression", ")"],
-      GROUP_CONCAT: ["GROUP_CONCAT", "(", "?DISTINCT", "expression", "?[;,SEPARATOR,=,string]", ")"]
+      GROUP_CONCAT: ["GROUP_CONCAT", "(", "?DISTINCT", "expression", "?[;,SEPARATOR,=,string]", ")"],
     },
     allowBnodes: {
-      "}": []
+      "}": [],
     },
     allowVars: {
-      "}": []
+      "}": [],
+    },
+    annotationPattern: {
+      "{|": ["{|", "propertyListNotEmpty", "|}"],
+    },
+    annotationPatternPath: {
+      "{|": ["{|", "propertyListPathNotEmpty", "|}"],
     },
     argList: {
       NIL: ["NIL"],
-      "(": ["(", "?DISTINCT", "expression", "*[,,expression]", ")"]
+      "(": ["(", "?DISTINCT", "expression", "*[,,expression]", ")"],
     },
     askQuery: {
-      ASK: ["ASK", "*datasetClause", "whereClause", "solutionModifier"]
+      ASK: ["ASK", "*datasetClause", "whereClause", "solutionModifier"],
     },
     baseDecl: {
-      BASE: ["BASE", "IRI_REF"]
+      BASE: ["BASE", "IRI_REF"],
     },
     bind: {
-      BIND: ["BIND", "(", "expression", "AS", "var", ")"]
+      BIND: ["BIND", "(", "expression", "AS", "var", ")"],
     },
     blankNode: {
       BLANK_NODE_LABEL: ["BLANK_NODE_LABEL"],
-      ANON: ["ANON"]
+      ANON: ["ANON"],
     },
     blankNodePropertyList: {
-      "[": ["[", "propertyListNotEmpty", "]"]
+      "[": ["[", "propertyListNotEmpty", "]"],
     },
     blankNodePropertyListPath: {
-      "[": ["[", "propertyListPathNotEmpty", "]"]
+      "[": ["[", "propertyListPathNotEmpty", "]"],
     },
     booleanLiteral: {
       TRUE: ["TRUE"],
-      FALSE: ["FALSE"]
+      FALSE: ["FALSE"],
     },
     brackettedExpression: {
-      "(": ["(", "expression", ")"]
+      "(": ["(", "expression", ")"],
     },
     builtInCall: {
       STR: ["STR", "(", "expression", ")"],
@@ -2148,16 +2945,21 @@ module.exports = {
       ISNUMERIC: ["ISNUMERIC", "(", "expression", ")"],
       REGEX: ["regexExpression"],
       EXISTS: ["existsFunc"],
-      NOT: ["notExistsFunc"]
+      NOT: ["notExistsFunc"],
+      TRIPLE: ["TRIPLE", "(", "expression", "expression", "expression", ")"],
+      SUBJECT: ["SUBJECT", "(", "expression", ")"],
+      PREDICATE: ["PREDICATE", "(", "expression", ")"],
+      OBJECT: ["OBJECT", "(", "expression", ")"],
+      isTRIPLE: ["isTRIPLE", "(", "expression", ")"],
     },
     clear: {
-      CLEAR: ["CLEAR", "?SILENT_2", "graphRefAll"]
+      CLEAR: ["CLEAR", "?SILENT_2", "graphRefAll"],
     },
     collection: {
-      "(": ["(", "+graphNode", ")"]
+      "(": ["(", "+graphNode", ")"],
     },
     collectionPath: {
-      "(": ["(", "+graphNodePath", ")"]
+      "(": ["(", "+graphNodePath", ")"],
     },
     conditionalAndExpression: {
       "!": ["valueLogical", "*[&&,valueLogical]"],
@@ -2215,8 +3017,14 @@ module.exports = {
       ISBLANK: ["valueLogical", "*[&&,valueLogical]"],
       ISLITERAL: ["valueLogical", "*[&&,valueLogical]"],
       ISNUMERIC: ["valueLogical", "*[&&,valueLogical]"],
+      TRIPLE: ["valueLogical", "*[&&,valueLogical]"],
+      SUBJECT: ["valueLogical", "*[&&,valueLogical]"],
+      PREDICATE: ["valueLogical", "*[&&,valueLogical]"],
+      OBJECT: ["valueLogical", "*[&&,valueLogical]"],
+      isTRIPLE: ["valueLogical", "*[&&,valueLogical]"],
       TRUE: ["valueLogical", "*[&&,valueLogical]"],
       FALSE: ["valueLogical", "*[&&,valueLogical]"],
+      "<<": ["valueLogical", "*[&&,valueLogical]"],
       COUNT: ["valueLogical", "*[&&,valueLogical]"],
       SUM: ["valueLogical", "*[&&,valueLogical]"],
       MIN: ["valueLogical", "*[&&,valueLogical]"],
@@ -2244,7 +3052,7 @@ module.exports = {
       DECIMAL_NEGATIVE: ["valueLogical", "*[&&,valueLogical]"],
       DOUBLE_NEGATIVE: ["valueLogical", "*[&&,valueLogical]"],
       PNAME_LN: ["valueLogical", "*[&&,valueLogical]"],
-      PNAME_NS: ["valueLogical", "*[&&,valueLogical]"]
+      PNAME_NS: ["valueLogical", "*[&&,valueLogical]"],
     },
     conditionalOrExpression: {
       "!": ["conditionalAndExpression", "*[||,conditionalAndExpression]"],
@@ -2302,8 +3110,14 @@ module.exports = {
       ISBLANK: ["conditionalAndExpression", "*[||,conditionalAndExpression]"],
       ISLITERAL: ["conditionalAndExpression", "*[||,conditionalAndExpression]"],
       ISNUMERIC: ["conditionalAndExpression", "*[||,conditionalAndExpression]"],
+      TRIPLE: ["conditionalAndExpression", "*[||,conditionalAndExpression]"],
+      SUBJECT: ["conditionalAndExpression", "*[||,conditionalAndExpression]"],
+      PREDICATE: ["conditionalAndExpression", "*[||,conditionalAndExpression]"],
+      OBJECT: ["conditionalAndExpression", "*[||,conditionalAndExpression]"],
+      isTRIPLE: ["conditionalAndExpression", "*[||,conditionalAndExpression]"],
       TRUE: ["conditionalAndExpression", "*[||,conditionalAndExpression]"],
       FALSE: ["conditionalAndExpression", "*[||,conditionalAndExpression]"],
+      "<<": ["conditionalAndExpression", "*[||,conditionalAndExpression]"],
       COUNT: ["conditionalAndExpression", "*[||,conditionalAndExpression]"],
       SUM: ["conditionalAndExpression", "*[||,conditionalAndExpression]"],
       MIN: ["conditionalAndExpression", "*[||,conditionalAndExpression]"],
@@ -2331,7 +3145,7 @@ module.exports = {
       DECIMAL_NEGATIVE: ["conditionalAndExpression", "*[||,conditionalAndExpression]"],
       DOUBLE_NEGATIVE: ["conditionalAndExpression", "*[||,conditionalAndExpression]"],
       PNAME_LN: ["conditionalAndExpression", "*[||,conditionalAndExpression]"],
-      PNAME_NS: ["conditionalAndExpression", "*[||,conditionalAndExpression]"]
+      PNAME_NS: ["conditionalAndExpression", "*[||,conditionalAndExpression]"],
     },
     constraint: {
       "(": ["brackettedExpression"],
@@ -2384,6 +3198,11 @@ module.exports = {
       ISBLANK: ["builtInCall"],
       ISLITERAL: ["builtInCall"],
       ISNUMERIC: ["builtInCall"],
+      TRIPLE: ["builtInCall"],
+      SUBJECT: ["builtInCall"],
+      PREDICATE: ["builtInCall"],
+      OBJECT: ["builtInCall"],
+      isTRIPLE: ["builtInCall"],
       SUBSTR: ["builtInCall"],
       REPLACE: ["builtInCall"],
       REGEX: ["builtInCall"],
@@ -2391,28 +3210,29 @@ module.exports = {
       NOT: ["builtInCall"],
       IRI_REF: ["functionCall"],
       PNAME_LN: ["functionCall"],
-      PNAME_NS: ["functionCall"]
+      PNAME_NS: ["functionCall"],
     },
     constructQuery: {
       CONSTRUCT: [
         "CONSTRUCT",
-        "or([[constructTemplate,*datasetClause,whereClause,solutionModifier],[*datasetClause,WHERE,{,?triplesTemplate,},solutionModifier]])"
-      ]
+        "or([[constructTemplate,*datasetClause,whereClause,solutionModifier],[*datasetClause,WHERE,{,?triplesTemplate,},solutionModifier]])",
+      ],
     },
     constructTemplate: {
-      "{": ["{", "?constructTriples", "}"]
+      "{": ["{", "?constructTriples", "}"],
     },
     constructTriples: {
       VAR1: ["triplesSameSubject", "?[.,?constructTriples]"],
       VAR2: ["triplesSameSubject", "?[.,?constructTriples]"],
       NIL: ["triplesSameSubject", "?[.,?constructTriples]"],
-      "(": ["triplesSameSubject", "?[.,?constructTriples]"],
-      "[": ["triplesSameSubject", "?[.,?constructTriples]"],
+      "<<": ["triplesSameSubject", "?[.,?constructTriples]"],
       IRI_REF: ["triplesSameSubject", "?[.,?constructTriples]"],
       TRUE: ["triplesSameSubject", "?[.,?constructTriples]"],
       FALSE: ["triplesSameSubject", "?[.,?constructTriples]"],
       BLANK_NODE_LABEL: ["triplesSameSubject", "?[.,?constructTriples]"],
       ANON: ["triplesSameSubject", "?[.,?constructTriples]"],
+      "(": ["triplesSameSubject", "?[.,?constructTriples]"],
+      "[": ["triplesSameSubject", "?[.,?constructTriples]"],
       PNAME_LN: ["triplesSameSubject", "?[.,?constructTriples]"],
       PNAME_NS: ["triplesSameSubject", "?[.,?constructTriples]"],
       STRING_LITERAL1: ["triplesSameSubject", "?[.,?constructTriples]"],
@@ -2427,21 +3247,22 @@ module.exports = {
       DOUBLE_POSITIVE: ["triplesSameSubject", "?[.,?constructTriples]"],
       INTEGER_NEGATIVE: ["triplesSameSubject", "?[.,?constructTriples]"],
       DECIMAL_NEGATIVE: ["triplesSameSubject", "?[.,?constructTriples]"],
-      DOUBLE_NEGATIVE: ["triplesSameSubject", "?[.,?constructTriples]"]
+      DOUBLE_NEGATIVE: ["triplesSameSubject", "?[.,?constructTriples]"],
     },
     copy: {
-      COPY: ["COPY", "?SILENT_4", "graphOrDefault", "TO", "graphOrDefault"]
+      COPY: ["COPY", "?SILENT_4", "graphOrDefault", "TO", "graphOrDefault"],
     },
     create: {
-      CREATE: ["CREATE", "?SILENT_3", "graphRef"]
+      CREATE: ["CREATE", "?SILENT_3", "graphRef"],
     },
     dataBlock: {
       NIL: ["or([inlineDataOneVar,inlineDataFull])"],
       "(": ["or([inlineDataOneVar,inlineDataFull])"],
       VAR1: ["or([inlineDataOneVar,inlineDataFull])"],
-      VAR2: ["or([inlineDataOneVar,inlineDataFull])"]
+      VAR2: ["or([inlineDataOneVar,inlineDataFull])"],
     },
     dataBlockValue: {
+      "<<": ["quotedTriple"],
       IRI_REF: ["iriRef"],
       PNAME_LN: ["iriRef"],
       PNAME_NS: ["iriRef"],
@@ -2460,29 +3281,50 @@ module.exports = {
       DOUBLE_NEGATIVE: ["numericLiteral"],
       TRUE: ["booleanLiteral"],
       FALSE: ["booleanLiteral"],
-      UNDEF: ["UNDEF"]
+      UNDEF: ["UNDEF"],
+    },
+    dataValueTerm: {
+      IRI_REF: ["iriRef"],
+      PNAME_LN: ["iriRef"],
+      PNAME_NS: ["iriRef"],
+      STRING_LITERAL1: ["rdfLiteral"],
+      STRING_LITERAL2: ["rdfLiteral"],
+      STRING_LITERAL_LONG1: ["rdfLiteral"],
+      STRING_LITERAL_LONG2: ["rdfLiteral"],
+      INTEGER: ["numericLiteral"],
+      DECIMAL: ["numericLiteral"],
+      DOUBLE: ["numericLiteral"],
+      INTEGER_POSITIVE: ["numericLiteral"],
+      DECIMAL_POSITIVE: ["numericLiteral"],
+      DOUBLE_POSITIVE: ["numericLiteral"],
+      INTEGER_NEGATIVE: ["numericLiteral"],
+      DECIMAL_NEGATIVE: ["numericLiteral"],
+      DOUBLE_NEGATIVE: ["numericLiteral"],
+      TRUE: ["booleanLiteral"],
+      FALSE: ["booleanLiteral"],
+      "<<": ["quotedTriple"],
     },
     datasetClause: {
-      FROM: ["FROM", "or([defaultGraphClause,namedGraphClause])"]
+      FROM: ["FROM", "or([defaultGraphClause,namedGraphClause])"],
     },
     defaultGraphClause: {
       IRI_REF: ["sourceSelector"],
       PNAME_LN: ["sourceSelector"],
-      PNAME_NS: ["sourceSelector"]
+      PNAME_NS: ["sourceSelector"],
     },
     delete1: {
       DATA: ["DATA", "quadDataNoBnodes"],
       WHERE: ["WHERE", "quadPatternNoBnodes"],
-      "{": ["quadPatternNoBnodes", "?insertClause", "*usingClause", "WHERE", "groupGraphPattern"]
+      "{": ["quadPatternNoBnodes", "?insertClause", "*usingClause", "WHERE", "groupGraphPattern"],
     },
     deleteClause: {
-      DELETE: ["DELETE", "quadPattern"]
+      DELETE: ["DELETE", "quadPattern"],
     },
     describeDatasetClause: {
-      FROM: ["FROM", "or([defaultGraphClause,namedGraphClause])"]
+      FROM: ["FROM", "or([defaultGraphClause,namedGraphClause])"],
     },
     describeQuery: {
-      DESCRIBE: ["DESCRIBE", "or([+varOrIRIref,*])", "*describeDatasetClause", "?whereClause", "solutionModifier"]
+      DESCRIBE: ["DESCRIBE", "or([+varOrIRIref,*])", "*describeDatasetClause", "?whereClause", "solutionModifier"],
     },
     disallowBnodes: {
       "}": [],
@@ -2490,13 +3332,14 @@ module.exports = {
       VAR1: [],
       VAR2: [],
       NIL: [],
-      "(": [],
-      "[": [],
+      "<<": [],
       IRI_REF: [],
       TRUE: [],
       FALSE: [],
       BLANK_NODE_LABEL: [],
       ANON: [],
+      "(": [],
+      "[": [],
       PNAME_LN: [],
       PNAME_NS: [],
       STRING_LITERAL1: [],
@@ -2511,7 +3354,7 @@ module.exports = {
       DOUBLE_POSITIVE: [],
       INTEGER_NEGATIVE: [],
       DECIMAL_NEGATIVE: [],
-      DOUBLE_NEGATIVE: []
+      DOUBLE_NEGATIVE: [],
     },
     disallowVars: {
       "}": [],
@@ -2519,13 +3362,14 @@ module.exports = {
       VAR1: [],
       VAR2: [],
       NIL: [],
-      "(": [],
-      "[": [],
+      "<<": [],
       IRI_REF: [],
       TRUE: [],
       FALSE: [],
       BLANK_NODE_LABEL: [],
       ANON: [],
+      "(": [],
+      "[": [],
       PNAME_LN: [],
       PNAME_NS: [],
       STRING_LITERAL1: [],
@@ -2540,13 +3384,39 @@ module.exports = {
       DOUBLE_POSITIVE: [],
       INTEGER_NEGATIVE: [],
       DECIMAL_NEGATIVE: [],
-      DOUBLE_NEGATIVE: []
+      DOUBLE_NEGATIVE: [],
     },
     drop: {
-      DROP: ["DROP", "?SILENT_2", "graphRefAll"]
+      DROP: ["DROP", "?SILENT_2", "graphRefAll"],
     },
     existsFunc: {
-      EXISTS: ["EXISTS", "groupGraphPattern"]
+      EXISTS: ["EXISTS", "groupGraphPattern"],
+    },
+    exprQuotedTP: {
+      "<<": ["<<", "exprVarOrTerm", "verb", "exprVarOrTerm", ">>"],
+    },
+    exprVarOrTerm: {
+      IRI_REF: ["iriRef"],
+      PNAME_LN: ["iriRef"],
+      PNAME_NS: ["iriRef"],
+      STRING_LITERAL1: ["rdfLiteral"],
+      STRING_LITERAL2: ["rdfLiteral"],
+      STRING_LITERAL_LONG1: ["rdfLiteral"],
+      STRING_LITERAL_LONG2: ["rdfLiteral"],
+      INTEGER: ["numericLiteral"],
+      DECIMAL: ["numericLiteral"],
+      DOUBLE: ["numericLiteral"],
+      INTEGER_POSITIVE: ["numericLiteral"],
+      DECIMAL_POSITIVE: ["numericLiteral"],
+      DOUBLE_POSITIVE: ["numericLiteral"],
+      INTEGER_NEGATIVE: ["numericLiteral"],
+      DECIMAL_NEGATIVE: ["numericLiteral"],
+      DOUBLE_NEGATIVE: ["numericLiteral"],
+      TRUE: ["booleanLiteral"],
+      FALSE: ["booleanLiteral"],
+      VAR1: ["var"],
+      VAR2: ["var"],
+      "<<": ["exprQuotedTP"],
     },
     expression: {
       "!": ["conditionalOrExpression"],
@@ -2604,8 +3474,14 @@ module.exports = {
       ISBLANK: ["conditionalOrExpression"],
       ISLITERAL: ["conditionalOrExpression"],
       ISNUMERIC: ["conditionalOrExpression"],
+      TRIPLE: ["conditionalOrExpression"],
+      SUBJECT: ["conditionalOrExpression"],
+      PREDICATE: ["conditionalOrExpression"],
+      OBJECT: ["conditionalOrExpression"],
+      isTRIPLE: ["conditionalOrExpression"],
       TRUE: ["conditionalOrExpression"],
       FALSE: ["conditionalOrExpression"],
+      "<<": ["conditionalOrExpression"],
       COUNT: ["conditionalOrExpression"],
       SUM: ["conditionalOrExpression"],
       MIN: ["conditionalOrExpression"],
@@ -2633,83 +3509,85 @@ module.exports = {
       DECIMAL_NEGATIVE: ["conditionalOrExpression"],
       DOUBLE_NEGATIVE: ["conditionalOrExpression"],
       PNAME_LN: ["conditionalOrExpression"],
-      PNAME_NS: ["conditionalOrExpression"]
+      PNAME_NS: ["conditionalOrExpression"],
     },
     expressionList: {
       NIL: ["NIL"],
-      "(": ["(", "expression", "*[,,expression]", ")"]
+      "(": ["(", "expression", "*[,,expression]", ")"],
     },
     filter: {
-      FILTER: ["FILTER", "constraint"]
+      FILTER: ["FILTER", "constraint"],
     },
     functionCall: {
       IRI_REF: ["iriRef", "argList"],
       PNAME_LN: ["iriRef", "argList"],
-      PNAME_NS: ["iriRef", "argList"]
+      PNAME_NS: ["iriRef", "argList"],
     },
     graphGraphPattern: {
-      GRAPH: ["GRAPH", "varOrIRIref", "groupGraphPattern"]
+      GRAPH: ["GRAPH", "varOrIRIref", "groupGraphPattern"],
     },
     graphNode: {
-      VAR1: ["varOrTerm"],
-      VAR2: ["varOrTerm"],
-      NIL: ["varOrTerm"],
-      IRI_REF: ["varOrTerm"],
-      TRUE: ["varOrTerm"],
-      FALSE: ["varOrTerm"],
-      BLANK_NODE_LABEL: ["varOrTerm"],
-      ANON: ["varOrTerm"],
-      PNAME_LN: ["varOrTerm"],
-      PNAME_NS: ["varOrTerm"],
-      STRING_LITERAL1: ["varOrTerm"],
-      STRING_LITERAL2: ["varOrTerm"],
-      STRING_LITERAL_LONG1: ["varOrTerm"],
-      STRING_LITERAL_LONG2: ["varOrTerm"],
-      INTEGER: ["varOrTerm"],
-      DECIMAL: ["varOrTerm"],
-      DOUBLE: ["varOrTerm"],
-      INTEGER_POSITIVE: ["varOrTerm"],
-      DECIMAL_POSITIVE: ["varOrTerm"],
-      DOUBLE_POSITIVE: ["varOrTerm"],
-      INTEGER_NEGATIVE: ["varOrTerm"],
-      DECIMAL_NEGATIVE: ["varOrTerm"],
-      DOUBLE_NEGATIVE: ["varOrTerm"],
+      VAR1: ["varOrTermOrQuotedTP"],
+      VAR2: ["varOrTermOrQuotedTP"],
+      NIL: ["varOrTermOrQuotedTP"],
+      "<<": ["varOrTermOrQuotedTP"],
+      IRI_REF: ["varOrTermOrQuotedTP"],
+      TRUE: ["varOrTermOrQuotedTP"],
+      FALSE: ["varOrTermOrQuotedTP"],
+      BLANK_NODE_LABEL: ["varOrTermOrQuotedTP"],
+      ANON: ["varOrTermOrQuotedTP"],
+      PNAME_LN: ["varOrTermOrQuotedTP"],
+      PNAME_NS: ["varOrTermOrQuotedTP"],
+      STRING_LITERAL1: ["varOrTermOrQuotedTP"],
+      STRING_LITERAL2: ["varOrTermOrQuotedTP"],
+      STRING_LITERAL_LONG1: ["varOrTermOrQuotedTP"],
+      STRING_LITERAL_LONG2: ["varOrTermOrQuotedTP"],
+      INTEGER: ["varOrTermOrQuotedTP"],
+      DECIMAL: ["varOrTermOrQuotedTP"],
+      DOUBLE: ["varOrTermOrQuotedTP"],
+      INTEGER_POSITIVE: ["varOrTermOrQuotedTP"],
+      DECIMAL_POSITIVE: ["varOrTermOrQuotedTP"],
+      DOUBLE_POSITIVE: ["varOrTermOrQuotedTP"],
+      INTEGER_NEGATIVE: ["varOrTermOrQuotedTP"],
+      DECIMAL_NEGATIVE: ["varOrTermOrQuotedTP"],
+      DOUBLE_NEGATIVE: ["varOrTermOrQuotedTP"],
       "(": ["triplesNode"],
-      "[": ["triplesNode"]
+      "[": ["triplesNode"],
     },
     graphNodePath: {
-      VAR1: ["varOrTerm"],
-      VAR2: ["varOrTerm"],
-      NIL: ["varOrTerm"],
-      IRI_REF: ["varOrTerm"],
-      TRUE: ["varOrTerm"],
-      FALSE: ["varOrTerm"],
-      BLANK_NODE_LABEL: ["varOrTerm"],
-      ANON: ["varOrTerm"],
-      PNAME_LN: ["varOrTerm"],
-      PNAME_NS: ["varOrTerm"],
-      STRING_LITERAL1: ["varOrTerm"],
-      STRING_LITERAL2: ["varOrTerm"],
-      STRING_LITERAL_LONG1: ["varOrTerm"],
-      STRING_LITERAL_LONG2: ["varOrTerm"],
-      INTEGER: ["varOrTerm"],
-      DECIMAL: ["varOrTerm"],
-      DOUBLE: ["varOrTerm"],
-      INTEGER_POSITIVE: ["varOrTerm"],
-      DECIMAL_POSITIVE: ["varOrTerm"],
-      DOUBLE_POSITIVE: ["varOrTerm"],
-      INTEGER_NEGATIVE: ["varOrTerm"],
-      DECIMAL_NEGATIVE: ["varOrTerm"],
-      DOUBLE_NEGATIVE: ["varOrTerm"],
+      VAR1: ["varOrTermOrQuotedTP"],
+      VAR2: ["varOrTermOrQuotedTP"],
+      NIL: ["varOrTermOrQuotedTP"],
+      "<<": ["varOrTermOrQuotedTP"],
+      IRI_REF: ["varOrTermOrQuotedTP"],
+      TRUE: ["varOrTermOrQuotedTP"],
+      FALSE: ["varOrTermOrQuotedTP"],
+      BLANK_NODE_LABEL: ["varOrTermOrQuotedTP"],
+      ANON: ["varOrTermOrQuotedTP"],
+      PNAME_LN: ["varOrTermOrQuotedTP"],
+      PNAME_NS: ["varOrTermOrQuotedTP"],
+      STRING_LITERAL1: ["varOrTermOrQuotedTP"],
+      STRING_LITERAL2: ["varOrTermOrQuotedTP"],
+      STRING_LITERAL_LONG1: ["varOrTermOrQuotedTP"],
+      STRING_LITERAL_LONG2: ["varOrTermOrQuotedTP"],
+      INTEGER: ["varOrTermOrQuotedTP"],
+      DECIMAL: ["varOrTermOrQuotedTP"],
+      DOUBLE: ["varOrTermOrQuotedTP"],
+      INTEGER_POSITIVE: ["varOrTermOrQuotedTP"],
+      DECIMAL_POSITIVE: ["varOrTermOrQuotedTP"],
+      DOUBLE_POSITIVE: ["varOrTermOrQuotedTP"],
+      INTEGER_NEGATIVE: ["varOrTermOrQuotedTP"],
+      DECIMAL_NEGATIVE: ["varOrTermOrQuotedTP"],
+      DOUBLE_NEGATIVE: ["varOrTermOrQuotedTP"],
       "(": ["triplesNodePath"],
-      "[": ["triplesNodePath"]
+      "[": ["triplesNodePath"],
     },
     graphOrDefault: {
       DEFAULT: ["DEFAULT"],
       IRI_REF: ["?GRAPH", "iriRef"],
       PNAME_LN: ["?GRAPH", "iriRef"],
       PNAME_NS: ["?GRAPH", "iriRef"],
-      GRAPH: ["?GRAPH", "iriRef"]
+      GRAPH: ["?GRAPH", "iriRef"],
     },
     graphPatternNotTriples: {
       "{": ["groupOrUnionGraphPattern"],
@@ -2719,16 +3597,16 @@ module.exports = {
       SERVICE: ["serviceGraphPattern"],
       FILTER: ["filter"],
       BIND: ["bind"],
-      VALUES: ["inlineData"]
+      VALUES: ["inlineData"],
     },
     graphRef: {
-      GRAPH: ["GRAPH", "iriRef"]
+      GRAPH: ["GRAPH", "iriRef"],
     },
     graphRefAll: {
       GRAPH: ["graphRef"],
       DEFAULT: ["DEFAULT"],
       NAMED: ["NAMED"],
-      ALL: ["ALL"]
+      ALL: ["ALL"],
     },
     graphTerm: {
       IRI_REF: ["iriRef"],
@@ -2751,10 +3629,10 @@ module.exports = {
       FALSE: ["booleanLiteral"],
       BLANK_NODE_LABEL: ["blankNode"],
       ANON: ["blankNode"],
-      NIL: ["NIL"]
+      NIL: ["NIL"],
     },
     groupClause: {
-      GROUP: ["GROUP", "BY", "+groupCondition"]
+      GROUP: ["GROUP", "BY", "+groupCondition"],
     },
     groupCondition: {
       STR: ["builtInCall"],
@@ -2806,6 +3684,11 @@ module.exports = {
       ISBLANK: ["builtInCall"],
       ISLITERAL: ["builtInCall"],
       ISNUMERIC: ["builtInCall"],
+      TRIPLE: ["builtInCall"],
+      SUBJECT: ["builtInCall"],
+      PREDICATE: ["builtInCall"],
+      OBJECT: ["builtInCall"],
+      isTRIPLE: ["builtInCall"],
       SUBSTR: ["builtInCall"],
       REPLACE: ["builtInCall"],
       REGEX: ["builtInCall"],
@@ -2816,10 +3699,10 @@ module.exports = {
       PNAME_NS: ["functionCall"],
       "(": ["(", "expression", "?[AS,var]", ")"],
       VAR1: ["var"],
-      VAR2: ["var"]
+      VAR2: ["var"],
     },
     groupGraphPattern: {
-      "{": ["{", "or([subSelect,groupGraphPatternSub])", "}"]
+      "{": ["{", "or([subSelect,groupGraphPatternSub])", "}"],
     },
     groupGraphPatternSub: {
       "{": ["?triplesBlock", "*[graphPatternNotTriples,?.,?triplesBlock]"],
@@ -2833,13 +3716,14 @@ module.exports = {
       VAR1: ["?triplesBlock", "*[graphPatternNotTriples,?.,?triplesBlock]"],
       VAR2: ["?triplesBlock", "*[graphPatternNotTriples,?.,?triplesBlock]"],
       NIL: ["?triplesBlock", "*[graphPatternNotTriples,?.,?triplesBlock]"],
-      "(": ["?triplesBlock", "*[graphPatternNotTriples,?.,?triplesBlock]"],
-      "[": ["?triplesBlock", "*[graphPatternNotTriples,?.,?triplesBlock]"],
+      "<<": ["?triplesBlock", "*[graphPatternNotTriples,?.,?triplesBlock]"],
       IRI_REF: ["?triplesBlock", "*[graphPatternNotTriples,?.,?triplesBlock]"],
       TRUE: ["?triplesBlock", "*[graphPatternNotTriples,?.,?triplesBlock]"],
       FALSE: ["?triplesBlock", "*[graphPatternNotTriples,?.,?triplesBlock]"],
       BLANK_NODE_LABEL: ["?triplesBlock", "*[graphPatternNotTriples,?.,?triplesBlock]"],
       ANON: ["?triplesBlock", "*[graphPatternNotTriples,?.,?triplesBlock]"],
+      "(": ["?triplesBlock", "*[graphPatternNotTriples,?.,?triplesBlock]"],
+      "[": ["?triplesBlock", "*[graphPatternNotTriples,?.,?triplesBlock]"],
       PNAME_LN: ["?triplesBlock", "*[graphPatternNotTriples,?.,?triplesBlock]"],
       PNAME_NS: ["?triplesBlock", "*[graphPatternNotTriples,?.,?triplesBlock]"],
       STRING_LITERAL1: ["?triplesBlock", "*[graphPatternNotTriples,?.,?triplesBlock]"],
@@ -2855,13 +3739,13 @@ module.exports = {
       INTEGER_NEGATIVE: ["?triplesBlock", "*[graphPatternNotTriples,?.,?triplesBlock]"],
       DECIMAL_NEGATIVE: ["?triplesBlock", "*[graphPatternNotTriples,?.,?triplesBlock]"],
       DOUBLE_NEGATIVE: ["?triplesBlock", "*[graphPatternNotTriples,?.,?triplesBlock]"],
-      "}": ["?triplesBlock", "*[graphPatternNotTriples,?.,?triplesBlock]"]
+      "}": ["?triplesBlock", "*[graphPatternNotTriples,?.,?triplesBlock]"],
     },
     groupOrUnionGraphPattern: {
-      "{": ["groupGraphPattern", "*[UNION,groupGraphPattern]"]
+      "{": ["groupGraphPattern", "*[UNION,groupGraphPattern]"],
     },
     havingClause: {
-      HAVING: ["HAVING", "+havingCondition"]
+      HAVING: ["HAVING", "+havingCondition"],
     },
     havingCondition: {
       "(": ["constraint"],
@@ -2914,6 +3798,11 @@ module.exports = {
       ISBLANK: ["constraint"],
       ISLITERAL: ["constraint"],
       ISNUMERIC: ["constraint"],
+      TRIPLE: ["constraint"],
+      SUBJECT: ["constraint"],
+      PREDICATE: ["constraint"],
+      OBJECT: ["constraint"],
+      isTRIPLE: ["constraint"],
       SUBSTR: ["constraint"],
       REPLACE: ["constraint"],
       REGEX: ["constraint"],
@@ -2921,51 +3810,51 @@ module.exports = {
       NOT: ["constraint"],
       IRI_REF: ["constraint"],
       PNAME_LN: ["constraint"],
-      PNAME_NS: ["constraint"]
+      PNAME_NS: ["constraint"],
     },
     inlineData: {
-      VALUES: ["VALUES", "dataBlock"]
+      VALUES: ["VALUES", "dataBlock"],
     },
     inlineDataFull: {
       NIL: ["or([NIL,[(,*var,)]])", "{", "*or([[(,*dataBlockValue,)],NIL])", "}"],
-      "(": ["or([NIL,[(,*var,)]])", "{", "*or([[(,*dataBlockValue,)],NIL])", "}"]
+      "(": ["or([NIL,[(,*var,)]])", "{", "*or([[(,*dataBlockValue,)],NIL])", "}"],
     },
     inlineDataOneVar: {
       VAR1: ["var", "{", "*dataBlockValue", "}"],
-      VAR2: ["var", "{", "*dataBlockValue", "}"]
+      VAR2: ["var", "{", "*dataBlockValue", "}"],
     },
     insert1: {
       DATA: ["DATA", "quadData"],
-      "{": ["quadPattern", "*usingClause", "WHERE", "groupGraphPattern"]
+      "{": ["quadPattern", "*usingClause", "WHERE", "groupGraphPattern"],
     },
     insertClause: {
-      INSERT: ["INSERT", "quadPattern"]
+      INSERT: ["INSERT", "quadPattern"],
     },
     integer: {
-      INTEGER: ["INTEGER"]
+      INTEGER: ["INTEGER"],
     },
     iriRef: {
       IRI_REF: ["IRI_REF"],
       PNAME_LN: ["prefixedName"],
-      PNAME_NS: ["prefixedName"]
+      PNAME_NS: ["prefixedName"],
     },
     iriRefOrFunction: {
       IRI_REF: ["iriRef", "?argList"],
       PNAME_LN: ["iriRef", "?argList"],
-      PNAME_NS: ["iriRef", "?argList"]
+      PNAME_NS: ["iriRef", "?argList"],
     },
     limitClause: {
-      LIMIT: ["LIMIT", "INTEGER"]
+      LIMIT: ["LIMIT", "INTEGER"],
     },
     limitOffsetClauses: {
       LIMIT: ["limitClause", "?offsetClause"],
-      OFFSET: ["offsetClause", "?limitClause"]
+      OFFSET: ["offsetClause", "?limitClause"],
     },
     load: {
-      LOAD: ["LOAD", "?SILENT_1", "iriRef", "?[INTO,graphRef]"]
+      LOAD: ["LOAD", "?SILENT_1", "iriRef", "?[INTO,graphRef]"],
     },
     minusGraphPattern: {
-      MINUS: ["MINUS", "groupGraphPattern"]
+      MINUS: ["MINUS", "groupGraphPattern"],
     },
     modify: {
       WITH: [
@@ -2974,11 +3863,11 @@ module.exports = {
         "or([[deleteClause,?insertClause],insertClause])",
         "*usingClause",
         "WHERE",
-        "groupGraphPattern"
-      ]
+        "groupGraphPattern",
+      ],
     },
     move: {
-      MOVE: ["MOVE", "?SILENT_4", "graphOrDefault", "TO", "graphOrDefault"]
+      MOVE: ["MOVE", "?SILENT_4", "graphOrDefault", "TO", "graphOrDefault"],
     },
     multiplicativeExpression: {
       "!": ["unaryExpression", "*or([[*,unaryExpression],[/,unaryExpression]])"],
@@ -3036,8 +3925,14 @@ module.exports = {
       ISBLANK: ["unaryExpression", "*or([[*,unaryExpression],[/,unaryExpression]])"],
       ISLITERAL: ["unaryExpression", "*or([[*,unaryExpression],[/,unaryExpression]])"],
       ISNUMERIC: ["unaryExpression", "*or([[*,unaryExpression],[/,unaryExpression]])"],
+      TRIPLE: ["unaryExpression", "*or([[*,unaryExpression],[/,unaryExpression]])"],
+      SUBJECT: ["unaryExpression", "*or([[*,unaryExpression],[/,unaryExpression]])"],
+      PREDICATE: ["unaryExpression", "*or([[*,unaryExpression],[/,unaryExpression]])"],
+      OBJECT: ["unaryExpression", "*or([[*,unaryExpression],[/,unaryExpression]])"],
+      isTRIPLE: ["unaryExpression", "*or([[*,unaryExpression],[/,unaryExpression]])"],
       TRUE: ["unaryExpression", "*or([[*,unaryExpression],[/,unaryExpression]])"],
       FALSE: ["unaryExpression", "*or([[*,unaryExpression],[/,unaryExpression]])"],
+      "<<": ["unaryExpression", "*or([[*,unaryExpression],[/,unaryExpression]])"],
       COUNT: ["unaryExpression", "*or([[*,unaryExpression],[/,unaryExpression]])"],
       SUM: ["unaryExpression", "*or([[*,unaryExpression],[/,unaryExpression]])"],
       MIN: ["unaryExpression", "*or([[*,unaryExpression],[/,unaryExpression]])"],
@@ -3065,13 +3960,13 @@ module.exports = {
       DECIMAL_NEGATIVE: ["unaryExpression", "*or([[*,unaryExpression],[/,unaryExpression]])"],
       DOUBLE_NEGATIVE: ["unaryExpression", "*or([[*,unaryExpression],[/,unaryExpression]])"],
       PNAME_LN: ["unaryExpression", "*or([[*,unaryExpression],[/,unaryExpression]])"],
-      PNAME_NS: ["unaryExpression", "*or([[*,unaryExpression],[/,unaryExpression]])"]
+      PNAME_NS: ["unaryExpression", "*or([[*,unaryExpression],[/,unaryExpression]])"],
     },
     namedGraphClause: {
-      NAMED: ["NAMED", "sourceSelector"]
+      NAMED: ["NAMED", "sourceSelector"],
     },
     notExistsFunc: {
-      NOT: ["NOT", "EXISTS", "groupGraphPattern"]
+      NOT: ["NOT", "EXISTS", "groupGraphPattern"],
     },
     numericExpression: {
       "!": ["additiveExpression"],
@@ -3129,8 +4024,14 @@ module.exports = {
       ISBLANK: ["additiveExpression"],
       ISLITERAL: ["additiveExpression"],
       ISNUMERIC: ["additiveExpression"],
+      TRIPLE: ["additiveExpression"],
+      SUBJECT: ["additiveExpression"],
+      PREDICATE: ["additiveExpression"],
+      OBJECT: ["additiveExpression"],
+      isTRIPLE: ["additiveExpression"],
       TRUE: ["additiveExpression"],
       FALSE: ["additiveExpression"],
+      "<<": ["additiveExpression"],
       COUNT: ["additiveExpression"],
       SUM: ["additiveExpression"],
       MIN: ["additiveExpression"],
@@ -3158,7 +4059,7 @@ module.exports = {
       DECIMAL_NEGATIVE: ["additiveExpression"],
       DOUBLE_NEGATIVE: ["additiveExpression"],
       PNAME_LN: ["additiveExpression"],
-      PNAME_NS: ["additiveExpression"]
+      PNAME_NS: ["additiveExpression"],
     },
     numericLiteral: {
       INTEGER: ["numericLiteralUnsigned"],
@@ -3169,56 +4070,58 @@ module.exports = {
       DOUBLE_POSITIVE: ["numericLiteralPositive"],
       INTEGER_NEGATIVE: ["numericLiteralNegative"],
       DECIMAL_NEGATIVE: ["numericLiteralNegative"],
-      DOUBLE_NEGATIVE: ["numericLiteralNegative"]
+      DOUBLE_NEGATIVE: ["numericLiteralNegative"],
     },
     numericLiteralNegative: {
       INTEGER_NEGATIVE: ["INTEGER_NEGATIVE"],
       DECIMAL_NEGATIVE: ["DECIMAL_NEGATIVE"],
-      DOUBLE_NEGATIVE: ["DOUBLE_NEGATIVE"]
+      DOUBLE_NEGATIVE: ["DOUBLE_NEGATIVE"],
     },
     numericLiteralPositive: {
       INTEGER_POSITIVE: ["INTEGER_POSITIVE"],
       DECIMAL_POSITIVE: ["DECIMAL_POSITIVE"],
-      DOUBLE_POSITIVE: ["DOUBLE_POSITIVE"]
+      DOUBLE_POSITIVE: ["DOUBLE_POSITIVE"],
     },
     numericLiteralUnsigned: {
       INTEGER: ["INTEGER"],
       DECIMAL: ["DECIMAL"],
-      DOUBLE: ["DOUBLE"]
+      DOUBLE: ["DOUBLE"],
     },
     object: {
-      "(": ["graphNode"],
-      "[": ["graphNode"],
-      VAR1: ["graphNode"],
-      VAR2: ["graphNode"],
-      NIL: ["graphNode"],
-      IRI_REF: ["graphNode"],
-      TRUE: ["graphNode"],
-      FALSE: ["graphNode"],
-      BLANK_NODE_LABEL: ["graphNode"],
-      ANON: ["graphNode"],
-      PNAME_LN: ["graphNode"],
-      PNAME_NS: ["graphNode"],
-      STRING_LITERAL1: ["graphNode"],
-      STRING_LITERAL2: ["graphNode"],
-      STRING_LITERAL_LONG1: ["graphNode"],
-      STRING_LITERAL_LONG2: ["graphNode"],
-      INTEGER: ["graphNode"],
-      DECIMAL: ["graphNode"],
-      DOUBLE: ["graphNode"],
-      INTEGER_POSITIVE: ["graphNode"],
-      DECIMAL_POSITIVE: ["graphNode"],
-      DOUBLE_POSITIVE: ["graphNode"],
-      INTEGER_NEGATIVE: ["graphNode"],
-      DECIMAL_NEGATIVE: ["graphNode"],
-      DOUBLE_NEGATIVE: ["graphNode"]
+      VAR1: ["graphNode", "?annotationPattern"],
+      VAR2: ["graphNode", "?annotationPattern"],
+      NIL: ["graphNode", "?annotationPattern"],
+      "<<": ["graphNode", "?annotationPattern"],
+      "(": ["graphNode", "?annotationPattern"],
+      "[": ["graphNode", "?annotationPattern"],
+      IRI_REF: ["graphNode", "?annotationPattern"],
+      TRUE: ["graphNode", "?annotationPattern"],
+      FALSE: ["graphNode", "?annotationPattern"],
+      BLANK_NODE_LABEL: ["graphNode", "?annotationPattern"],
+      ANON: ["graphNode", "?annotationPattern"],
+      PNAME_LN: ["graphNode", "?annotationPattern"],
+      PNAME_NS: ["graphNode", "?annotationPattern"],
+      STRING_LITERAL1: ["graphNode", "?annotationPattern"],
+      STRING_LITERAL2: ["graphNode", "?annotationPattern"],
+      STRING_LITERAL_LONG1: ["graphNode", "?annotationPattern"],
+      STRING_LITERAL_LONG2: ["graphNode", "?annotationPattern"],
+      INTEGER: ["graphNode", "?annotationPattern"],
+      DECIMAL: ["graphNode", "?annotationPattern"],
+      DOUBLE: ["graphNode", "?annotationPattern"],
+      INTEGER_POSITIVE: ["graphNode", "?annotationPattern"],
+      DECIMAL_POSITIVE: ["graphNode", "?annotationPattern"],
+      DOUBLE_POSITIVE: ["graphNode", "?annotationPattern"],
+      INTEGER_NEGATIVE: ["graphNode", "?annotationPattern"],
+      DECIMAL_NEGATIVE: ["graphNode", "?annotationPattern"],
+      DOUBLE_NEGATIVE: ["graphNode", "?annotationPattern"],
     },
     objectList: {
-      "(": ["object", "*[,,object]"],
-      "[": ["object", "*[,,object]"],
       VAR1: ["object", "*[,,object]"],
       VAR2: ["object", "*[,,object]"],
       NIL: ["object", "*[,,object]"],
+      "<<": ["object", "*[,,object]"],
+      "(": ["object", "*[,,object]"],
+      "[": ["object", "*[,,object]"],
       IRI_REF: ["object", "*[,,object]"],
       TRUE: ["object", "*[,,object]"],
       FALSE: ["object", "*[,,object]"],
@@ -3238,14 +4141,15 @@ module.exports = {
       DOUBLE_POSITIVE: ["object", "*[,,object]"],
       INTEGER_NEGATIVE: ["object", "*[,,object]"],
       DECIMAL_NEGATIVE: ["object", "*[,,object]"],
-      DOUBLE_NEGATIVE: ["object", "*[,,object]"]
+      DOUBLE_NEGATIVE: ["object", "*[,,object]"],
     },
     objectListPath: {
-      "(": ["objectPath", "*[,,objectPath]"],
-      "[": ["objectPath", "*[,,objectPath]"],
       VAR1: ["objectPath", "*[,,objectPath]"],
       VAR2: ["objectPath", "*[,,objectPath]"],
       NIL: ["objectPath", "*[,,objectPath]"],
+      "<<": ["objectPath", "*[,,objectPath]"],
+      "(": ["objectPath", "*[,,objectPath]"],
+      "[": ["objectPath", "*[,,objectPath]"],
       IRI_REF: ["objectPath", "*[,,objectPath]"],
       TRUE: ["objectPath", "*[,,objectPath]"],
       FALSE: ["objectPath", "*[,,objectPath]"],
@@ -3265,40 +4169,41 @@ module.exports = {
       DOUBLE_POSITIVE: ["objectPath", "*[,,objectPath]"],
       INTEGER_NEGATIVE: ["objectPath", "*[,,objectPath]"],
       DECIMAL_NEGATIVE: ["objectPath", "*[,,objectPath]"],
-      DOUBLE_NEGATIVE: ["objectPath", "*[,,objectPath]"]
+      DOUBLE_NEGATIVE: ["objectPath", "*[,,objectPath]"],
     },
     objectPath: {
-      "(": ["graphNodePath"],
-      "[": ["graphNodePath"],
-      VAR1: ["graphNodePath"],
-      VAR2: ["graphNodePath"],
-      NIL: ["graphNodePath"],
-      IRI_REF: ["graphNodePath"],
-      TRUE: ["graphNodePath"],
-      FALSE: ["graphNodePath"],
-      BLANK_NODE_LABEL: ["graphNodePath"],
-      ANON: ["graphNodePath"],
-      PNAME_LN: ["graphNodePath"],
-      PNAME_NS: ["graphNodePath"],
-      STRING_LITERAL1: ["graphNodePath"],
-      STRING_LITERAL2: ["graphNodePath"],
-      STRING_LITERAL_LONG1: ["graphNodePath"],
-      STRING_LITERAL_LONG2: ["graphNodePath"],
-      INTEGER: ["graphNodePath"],
-      DECIMAL: ["graphNodePath"],
-      DOUBLE: ["graphNodePath"],
-      INTEGER_POSITIVE: ["graphNodePath"],
-      DECIMAL_POSITIVE: ["graphNodePath"],
-      DOUBLE_POSITIVE: ["graphNodePath"],
-      INTEGER_NEGATIVE: ["graphNodePath"],
-      DECIMAL_NEGATIVE: ["graphNodePath"],
-      DOUBLE_NEGATIVE: ["graphNodePath"]
+      VAR1: ["graphNodePath", "?annotationPatternPath"],
+      VAR2: ["graphNodePath", "?annotationPatternPath"],
+      NIL: ["graphNodePath", "?annotationPatternPath"],
+      "<<": ["graphNodePath", "?annotationPatternPath"],
+      "(": ["graphNodePath", "?annotationPatternPath"],
+      "[": ["graphNodePath", "?annotationPatternPath"],
+      IRI_REF: ["graphNodePath", "?annotationPatternPath"],
+      TRUE: ["graphNodePath", "?annotationPatternPath"],
+      FALSE: ["graphNodePath", "?annotationPatternPath"],
+      BLANK_NODE_LABEL: ["graphNodePath", "?annotationPatternPath"],
+      ANON: ["graphNodePath", "?annotationPatternPath"],
+      PNAME_LN: ["graphNodePath", "?annotationPatternPath"],
+      PNAME_NS: ["graphNodePath", "?annotationPatternPath"],
+      STRING_LITERAL1: ["graphNodePath", "?annotationPatternPath"],
+      STRING_LITERAL2: ["graphNodePath", "?annotationPatternPath"],
+      STRING_LITERAL_LONG1: ["graphNodePath", "?annotationPatternPath"],
+      STRING_LITERAL_LONG2: ["graphNodePath", "?annotationPatternPath"],
+      INTEGER: ["graphNodePath", "?annotationPatternPath"],
+      DECIMAL: ["graphNodePath", "?annotationPatternPath"],
+      DOUBLE: ["graphNodePath", "?annotationPatternPath"],
+      INTEGER_POSITIVE: ["graphNodePath", "?annotationPatternPath"],
+      DECIMAL_POSITIVE: ["graphNodePath", "?annotationPatternPath"],
+      DOUBLE_POSITIVE: ["graphNodePath", "?annotationPatternPath"],
+      INTEGER_NEGATIVE: ["graphNodePath", "?annotationPatternPath"],
+      DECIMAL_NEGATIVE: ["graphNodePath", "?annotationPatternPath"],
+      DOUBLE_NEGATIVE: ["graphNodePath", "?annotationPatternPath"],
     },
     offsetClause: {
-      OFFSET: ["OFFSET", "INTEGER"]
+      OFFSET: ["OFFSET", "INTEGER"],
     },
     optionalGraphPattern: {
-      OPTIONAL: ["OPTIONAL", "groupGraphPattern"]
+      OPTIONAL: ["OPTIONAL", "groupGraphPattern"],
     },
     "or([*,expression])": {
       "*": ["*"],
@@ -3357,8 +4262,14 @@ module.exports = {
       ISBLANK: ["expression"],
       ISLITERAL: ["expression"],
       ISNUMERIC: ["expression"],
+      TRIPLE: ["expression"],
+      SUBJECT: ["expression"],
+      PREDICATE: ["expression"],
+      OBJECT: ["expression"],
+      isTRIPLE: ["expression"],
       TRUE: ["expression"],
       FALSE: ["expression"],
+      "<<": ["expression"],
       COUNT: ["expression"],
       SUM: ["expression"],
       MIN: ["expression"],
@@ -3386,13 +4297,13 @@ module.exports = {
       DECIMAL_NEGATIVE: ["expression"],
       DOUBLE_NEGATIVE: ["expression"],
       PNAME_LN: ["expression"],
-      PNAME_NS: ["expression"]
+      PNAME_NS: ["expression"],
     },
     "or([+or([var,[(,expression,AS,var,)]]),*])": {
       "(": ["+or([var,[(,expression,AS,var,)]])"],
       VAR1: ["+or([var,[(,expression,AS,var,)]])"],
       VAR2: ["+or([var,[(,expression,AS,var,)]])"],
-      "*": ["*"]
+      "*": ["*"],
     },
     "or([+varOrIRIref,*])": {
       VAR1: ["+varOrIRIref"],
@@ -3400,61 +4311,61 @@ module.exports = {
       IRI_REF: ["+varOrIRIref"],
       PNAME_LN: ["+varOrIRIref"],
       PNAME_NS: ["+varOrIRIref"],
-      "*": ["*"]
+      "*": ["*"],
     },
     "or([ASC,DESC])": {
       ASC: ["ASC"],
-      DESC: ["DESC"]
+      DESC: ["DESC"],
     },
     "or([DISTINCT,REDUCED])": {
       DISTINCT: ["DISTINCT"],
-      REDUCED: ["REDUCED"]
+      REDUCED: ["REDUCED"],
     },
     "or([LANGTAG,[^^,iriRef]])": {
       LANGTAG: ["LANGTAG"],
-      "^^": ["[^^,iriRef]"]
+      "^^": ["[^^,iriRef]"],
     },
     "or([NIL,[(,*var,)]])": {
       NIL: ["NIL"],
-      "(": ["[(,*var,)]"]
+      "(": ["[(,*var,)]"],
     },
     "or([[(,*dataBlockValue,)],NIL])": {
       "(": ["[(,*dataBlockValue,)]"],
-      NIL: ["NIL"]
+      NIL: ["NIL"],
     },
     "or([[(,expression,)],NIL])": {
       "(": ["[(,expression,)]"],
-      NIL: ["NIL"]
+      NIL: ["NIL"],
     },
     "or([[*,unaryExpression],[/,unaryExpression]])": {
       "*": ["[*,unaryExpression]"],
-      "/": ["[/,unaryExpression]"]
+      "/": ["[/,unaryExpression]"],
     },
     "or([[+,multiplicativeExpression],[-,multiplicativeExpression],[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]])": {
       "+": ["[+,multiplicativeExpression]"],
       "-": ["[-,multiplicativeExpression]"],
       INTEGER_POSITIVE: [
-        "[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]"
+        "[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]",
       ],
       DECIMAL_POSITIVE: [
-        "[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]"
+        "[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]",
       ],
       DOUBLE_POSITIVE: [
-        "[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]"
+        "[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]",
       ],
       INTEGER_NEGATIVE: [
-        "[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]"
+        "[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]",
       ],
       DECIMAL_NEGATIVE: [
-        "[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]"
+        "[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]",
       ],
       DOUBLE_NEGATIVE: [
-        "[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]"
-      ]
+        "[or([numericLiteralPositive,numericLiteralNegative]),?or([[*,unaryExpression],[/,unaryExpression]])]",
+      ],
     },
     "or([[,,or([},[integer,}]])],}])": {
       ",": ["[,,or([},[integer,}]])]"],
-      "}": ["}"]
+      "}": ["}"],
     },
     "or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])": {
       "=": ["[=,numericExpression]"],
@@ -3464,48 +4375,48 @@ module.exports = {
       "<=": ["[<=,numericExpression]"],
       ">=": ["[>=,numericExpression]"],
       IN: ["[IN,expressionList]"],
-      NOT: ["[NOT,IN,expressionList]"]
+      NOT: ["[NOT,IN,expressionList]"],
     },
     "or([[constructTemplate,*datasetClause,whereClause,solutionModifier],[*datasetClause,WHERE,{,?triplesTemplate,},solutionModifier]])": {
       "{": ["[constructTemplate,*datasetClause,whereClause,solutionModifier]"],
       WHERE: ["[*datasetClause,WHERE,{,?triplesTemplate,},solutionModifier]"],
-      FROM: ["[*datasetClause,WHERE,{,?triplesTemplate,},solutionModifier]"]
+      FROM: ["[*datasetClause,WHERE,{,?triplesTemplate,},solutionModifier]"],
     },
     "or([[deleteClause,?insertClause],insertClause])": {
       DELETE: ["[deleteClause,?insertClause]"],
-      INSERT: ["insertClause"]
+      INSERT: ["insertClause"],
     },
     "or([[integer,or([[,,or([},[integer,}]])],}])],[,,integer,}]])": {
       INTEGER: ["[integer,or([[,,or([},[integer,}]])],}])]"],
-      ",": ["[,,integer,}]"]
+      ",": ["[,,integer,}]"],
     },
     "or([baseDecl,prefixDecl])": {
       BASE: ["baseDecl"],
-      PREFIX: ["prefixDecl"]
+      PREFIX: ["prefixDecl"],
     },
     "or([defaultGraphClause,namedGraphClause])": {
       IRI_REF: ["defaultGraphClause"],
       PNAME_LN: ["defaultGraphClause"],
       PNAME_NS: ["defaultGraphClause"],
-      NAMED: ["namedGraphClause"]
+      NAMED: ["namedGraphClause"],
     },
     "or([inlineDataOneVar,inlineDataFull])": {
       VAR1: ["inlineDataOneVar"],
       VAR2: ["inlineDataOneVar"],
       NIL: ["inlineDataFull"],
-      "(": ["inlineDataFull"]
+      "(": ["inlineDataFull"],
     },
     "or([iriRef,[NAMED,iriRef]])": {
       IRI_REF: ["iriRef"],
       PNAME_LN: ["iriRef"],
       PNAME_NS: ["iriRef"],
-      NAMED: ["[NAMED,iriRef]"]
+      NAMED: ["[NAMED,iriRef]"],
     },
     "or([iriRef,a])": {
       IRI_REF: ["iriRef"],
       PNAME_LN: ["iriRef"],
       PNAME_NS: ["iriRef"],
-      a: ["a"]
+      a: ["a"],
     },
     "or([numericLiteralPositive,numericLiteralNegative])": {
       INTEGER_POSITIVE: ["numericLiteralPositive"],
@@ -3513,7 +4424,7 @@ module.exports = {
       DOUBLE_POSITIVE: ["numericLiteralPositive"],
       INTEGER_NEGATIVE: ["numericLiteralNegative"],
       DECIMAL_NEGATIVE: ["numericLiteralNegative"],
-      DOUBLE_NEGATIVE: ["numericLiteralNegative"]
+      DOUBLE_NEGATIVE: ["numericLiteralNegative"],
     },
     "or([queryAll,updateAll])": {
       CONSTRUCT: ["queryAll"],
@@ -3530,13 +4441,13 @@ module.exports = {
       COPY: ["updateAll"],
       CREATE: ["updateAll"],
       WITH: ["updateAll"],
-      $: ["updateAll"]
+      $: ["updateAll"],
     },
     "or([selectQuery,constructQuery,describeQuery,askQuery])": {
       SELECT: ["selectQuery"],
       CONSTRUCT: ["constructQuery"],
       DESCRIBE: ["describeQuery"],
-      ASK: ["askQuery"]
+      ASK: ["askQuery"],
     },
     "or([subSelect,groupGraphPatternSub])": {
       SELECT: ["subSelect"],
@@ -3551,13 +4462,14 @@ module.exports = {
       VAR1: ["groupGraphPatternSub"],
       VAR2: ["groupGraphPatternSub"],
       NIL: ["groupGraphPatternSub"],
-      "(": ["groupGraphPatternSub"],
-      "[": ["groupGraphPatternSub"],
+      "<<": ["groupGraphPatternSub"],
       IRI_REF: ["groupGraphPatternSub"],
       TRUE: ["groupGraphPatternSub"],
       FALSE: ["groupGraphPatternSub"],
       BLANK_NODE_LABEL: ["groupGraphPatternSub"],
       ANON: ["groupGraphPatternSub"],
+      "(": ["groupGraphPatternSub"],
+      "[": ["groupGraphPatternSub"],
       PNAME_LN: ["groupGraphPatternSub"],
       PNAME_NS: ["groupGraphPatternSub"],
       STRING_LITERAL1: ["groupGraphPatternSub"],
@@ -3573,12 +4485,12 @@ module.exports = {
       INTEGER_NEGATIVE: ["groupGraphPatternSub"],
       DECIMAL_NEGATIVE: ["groupGraphPatternSub"],
       DOUBLE_NEGATIVE: ["groupGraphPatternSub"],
-      "}": ["groupGraphPatternSub"]
+      "}": ["groupGraphPatternSub"],
     },
     "or([var,[(,expression,AS,var,)]])": {
       VAR1: ["var"],
       VAR2: ["var"],
-      "(": ["[(,expression,AS,var,)]"]
+      "(": ["[(,expression,AS,var,)]"],
     },
     "or([verbPath,verbSimple])": {
       "^": ["verbPath"],
@@ -3589,14 +4501,14 @@ module.exports = {
       PNAME_LN: ["verbPath"],
       PNAME_NS: ["verbPath"],
       VAR1: ["verbSimple"],
-      VAR2: ["verbSimple"]
+      VAR2: ["verbSimple"],
     },
     "or([},[integer,}]])": {
       "}": ["}"],
-      INTEGER: ["[integer,}]"]
+      INTEGER: ["[integer,}]"],
     },
     orderClause: {
-      ORDER: ["ORDER", "BY", "+orderCondition"]
+      ORDER: ["ORDER", "BY", "+orderCondition"],
     },
     orderCondition: {
       ASC: ["or([ASC,DESC])", "brackettedExpression"],
@@ -3651,6 +4563,11 @@ module.exports = {
       ISBLANK: ["constraint"],
       ISLITERAL: ["constraint"],
       ISNUMERIC: ["constraint"],
+      TRIPLE: ["constraint"],
+      SUBJECT: ["constraint"],
+      PREDICATE: ["constraint"],
+      OBJECT: ["constraint"],
+      isTRIPLE: ["constraint"],
       SUBSTR: ["constraint"],
       REPLACE: ["constraint"],
       REGEX: ["constraint"],
@@ -3660,7 +4577,7 @@ module.exports = {
       PNAME_LN: ["constraint"],
       PNAME_NS: ["constraint"],
       VAR1: ["var"],
-      VAR2: ["var"]
+      VAR2: ["var"],
     },
     path: {
       "^": ["pathAlternative"],
@@ -3669,7 +4586,7 @@ module.exports = {
       "(": ["pathAlternative"],
       IRI_REF: ["pathAlternative"],
       PNAME_LN: ["pathAlternative"],
-      PNAME_NS: ["pathAlternative"]
+      PNAME_NS: ["pathAlternative"],
     },
     pathAlternative: {
       "^": ["pathSequence", "*[|,pathSequence]"],
@@ -3678,7 +4595,7 @@ module.exports = {
       "(": ["pathSequence", "*[|,pathSequence]"],
       IRI_REF: ["pathSequence", "*[|,pathSequence]"],
       PNAME_LN: ["pathSequence", "*[|,pathSequence]"],
-      PNAME_NS: ["pathSequence", "*[|,pathSequence]"]
+      PNAME_NS: ["pathSequence", "*[|,pathSequence]"],
     },
     pathElt: {
       a: ["pathPrimary", "?pathMod"],
@@ -3686,7 +4603,7 @@ module.exports = {
       "(": ["pathPrimary", "?pathMod"],
       IRI_REF: ["pathPrimary", "?pathMod"],
       PNAME_LN: ["pathPrimary", "?pathMod"],
-      PNAME_NS: ["pathPrimary", "?pathMod"]
+      PNAME_NS: ["pathPrimary", "?pathMod"],
     },
     pathEltOrInverse: {
       a: ["pathElt"],
@@ -3695,13 +4612,13 @@ module.exports = {
       IRI_REF: ["pathElt"],
       PNAME_LN: ["pathElt"],
       PNAME_NS: ["pathElt"],
-      "^": ["^", "pathElt"]
+      "^": ["^", "pathElt"],
     },
     pathMod: {
       "*": ["*"],
       "?": ["?"],
       "+": ["+"],
-      "{": ["{", "or([[integer,or([[,,or([},[integer,}]])],}])],[,,integer,}]])"]
+      "{": ["{", "or([[integer,or([[,,or([},[integer,}]])],}])],[,,integer,}]])"],
     },
     pathNegatedPropertySet: {
       a: ["pathOneInPropertySet"],
@@ -3709,14 +4626,14 @@ module.exports = {
       IRI_REF: ["pathOneInPropertySet"],
       PNAME_LN: ["pathOneInPropertySet"],
       PNAME_NS: ["pathOneInPropertySet"],
-      "(": ["(", "?[pathOneInPropertySet,*[|,pathOneInPropertySet]]", ")"]
+      "(": ["(", "?[pathOneInPropertySet,*[|,pathOneInPropertySet]]", ")"],
     },
     pathOneInPropertySet: {
       IRI_REF: ["iriRef"],
       PNAME_LN: ["iriRef"],
       PNAME_NS: ["iriRef"],
       a: ["a"],
-      "^": ["^", "or([iriRef,a])"]
+      "^": ["^", "or([iriRef,a])"],
     },
     pathPrimary: {
       IRI_REF: ["storeProperty", "iriRef"],
@@ -3724,7 +4641,7 @@ module.exports = {
       PNAME_NS: ["storeProperty", "iriRef"],
       a: ["storeProperty", "a"],
       "!": ["!", "pathNegatedPropertySet"],
-      "(": ["(", "path", ")"]
+      "(": ["(", "path", ")"],
     },
     pathSequence: {
       "^": ["pathEltOrInverse", "*[/,pathEltOrInverse]"],
@@ -3733,14 +4650,14 @@ module.exports = {
       "(": ["pathEltOrInverse", "*[/,pathEltOrInverse]"],
       IRI_REF: ["pathEltOrInverse", "*[/,pathEltOrInverse]"],
       PNAME_LN: ["pathEltOrInverse", "*[/,pathEltOrInverse]"],
-      PNAME_NS: ["pathEltOrInverse", "*[/,pathEltOrInverse]"]
+      PNAME_NS: ["pathEltOrInverse", "*[/,pathEltOrInverse]"],
     },
     prefixDecl: {
-      PREFIX: ["PREFIX", "PNAME_NS", "IRI_REF"]
+      PREFIX: ["PREFIX", "PNAME_NS", "IRI_REF"],
     },
     prefixedName: {
       PNAME_LN: ["PNAME_LN"],
-      PNAME_NS: ["PNAME_NS"]
+      PNAME_NS: ["PNAME_NS"],
     },
     primaryExpression: {
       "(": ["brackettedExpression"],
@@ -3793,6 +4710,11 @@ module.exports = {
       ISBLANK: ["builtInCall"],
       ISLITERAL: ["builtInCall"],
       ISNUMERIC: ["builtInCall"],
+      TRIPLE: ["builtInCall"],
+      SUBJECT: ["builtInCall"],
+      PREDICATE: ["builtInCall"],
+      OBJECT: ["builtInCall"],
+      isTRIPLE: ["builtInCall"],
       SUBSTR: ["builtInCall"],
       REPLACE: ["builtInCall"],
       REGEX: ["builtInCall"],
@@ -3818,13 +4740,14 @@ module.exports = {
       FALSE: ["booleanLiteral"],
       VAR1: ["var"],
       VAR2: ["var"],
+      "<<": ["exprQuotedTP"],
       COUNT: ["aggregate"],
       SUM: ["aggregate"],
       MIN: ["aggregate"],
       MAX: ["aggregate"],
       AVG: ["aggregate"],
       SAMPLE: ["aggregate"],
-      GROUP_CONCAT: ["aggregate"]
+      GROUP_CONCAT: ["aggregate"],
     },
     prologue: {
       BASE: ["*or([baseDecl,prefixDecl])"],
@@ -3843,7 +4766,7 @@ module.exports = {
       MOVE: ["*or([baseDecl,prefixDecl])"],
       COPY: ["*or([baseDecl,prefixDecl])"],
       CREATE: ["*or([baseDecl,prefixDecl])"],
-      WITH: ["*or([baseDecl,prefixDecl])"]
+      WITH: ["*or([baseDecl,prefixDecl])"],
     },
     propertyList: {
       a: ["propertyListNotEmpty"],
@@ -3854,7 +4777,7 @@ module.exports = {
       PNAME_NS: ["propertyListNotEmpty"],
       ".": [],
       "}": [],
-      GRAPH: []
+      GRAPH: [],
     },
     propertyListNotEmpty: {
       a: ["verb", "objectList", "*[;,?[verb,objectList]]"],
@@ -3862,7 +4785,7 @@ module.exports = {
       VAR2: ["verb", "objectList", "*[;,?[verb,objectList]]"],
       IRI_REF: ["verb", "objectList", "*[;,?[verb,objectList]]"],
       PNAME_LN: ["verb", "objectList", "*[;,?[verb,objectList]]"],
-      PNAME_NS: ["verb", "objectList", "*[;,?[verb,objectList]]"]
+      PNAME_NS: ["verb", "objectList", "*[;,?[verb,objectList]]"],
     },
     propertyListPath: {
       a: ["propertyListNotEmpty"],
@@ -3880,7 +4803,7 @@ module.exports = {
       FILTER: [],
       BIND: [],
       VALUES: [],
-      "}": []
+      "}": [],
     },
     propertyListPathNotEmpty: {
       VAR1: ["or([verbPath,verbSimple])", "objectListPath", "*[;,?[or([verbPath,verbSimple]),objectListPath]]"],
@@ -3891,32 +4814,58 @@ module.exports = {
       "(": ["or([verbPath,verbSimple])", "objectListPath", "*[;,?[or([verbPath,verbSimple]),objectListPath]]"],
       IRI_REF: ["or([verbPath,verbSimple])", "objectListPath", "*[;,?[or([verbPath,verbSimple]),objectListPath]]"],
       PNAME_LN: ["or([verbPath,verbSimple])", "objectListPath", "*[;,?[or([verbPath,verbSimple]),objectListPath]]"],
-      PNAME_NS: ["or([verbPath,verbSimple])", "objectListPath", "*[;,?[or([verbPath,verbSimple]),objectListPath]]"]
+      PNAME_NS: ["or([verbPath,verbSimple])", "objectListPath", "*[;,?[or([verbPath,verbSimple]),objectListPath]]"],
+    },
+    qtSubjectOrObject: {
+      VAR1: ["var"],
+      VAR2: ["var"],
+      BLANK_NODE_LABEL: ["blankNode"],
+      ANON: ["blankNode"],
+      IRI_REF: ["iriRef"],
+      PNAME_LN: ["iriRef"],
+      PNAME_NS: ["iriRef"],
+      STRING_LITERAL1: ["rdfLiteral"],
+      STRING_LITERAL2: ["rdfLiteral"],
+      STRING_LITERAL_LONG1: ["rdfLiteral"],
+      STRING_LITERAL_LONG2: ["rdfLiteral"],
+      INTEGER: ["numericLiteral"],
+      DECIMAL: ["numericLiteral"],
+      DOUBLE: ["numericLiteral"],
+      INTEGER_POSITIVE: ["numericLiteral"],
+      DECIMAL_POSITIVE: ["numericLiteral"],
+      DOUBLE_POSITIVE: ["numericLiteral"],
+      INTEGER_NEGATIVE: ["numericLiteral"],
+      DECIMAL_NEGATIVE: ["numericLiteral"],
+      DOUBLE_NEGATIVE: ["numericLiteral"],
+      TRUE: ["booleanLiteral"],
+      FALSE: ["booleanLiteral"],
+      "<<": ["quotedTP"],
     },
     quadData: {
-      "{": ["{", "disallowVars", "quads", "allowVars", "}"]
+      "{": ["{", "disallowVars", "quads", "allowVars", "}"],
     },
     quadDataNoBnodes: {
-      "{": ["{", "disallowBnodes", "disallowVars", "quads", "allowVars", "allowBnodes", "}"]
+      "{": ["{", "disallowBnodes", "disallowVars", "quads", "allowVars", "allowBnodes", "}"],
     },
     quadPattern: {
-      "{": ["{", "quads", "}"]
+      "{": ["{", "quads", "}"],
     },
     quadPatternNoBnodes: {
-      "{": ["{", "disallowBnodes", "quads", "allowBnodes", "}"]
+      "{": ["{", "disallowBnodes", "quads", "allowBnodes", "}"],
     },
     quads: {
       GRAPH: ["?triplesTemplate", "*[quadsNotTriples,?.,?triplesTemplate]"],
       VAR1: ["?triplesTemplate", "*[quadsNotTriples,?.,?triplesTemplate]"],
       VAR2: ["?triplesTemplate", "*[quadsNotTriples,?.,?triplesTemplate]"],
       NIL: ["?triplesTemplate", "*[quadsNotTriples,?.,?triplesTemplate]"],
-      "(": ["?triplesTemplate", "*[quadsNotTriples,?.,?triplesTemplate]"],
-      "[": ["?triplesTemplate", "*[quadsNotTriples,?.,?triplesTemplate]"],
+      "<<": ["?triplesTemplate", "*[quadsNotTriples,?.,?triplesTemplate]"],
       IRI_REF: ["?triplesTemplate", "*[quadsNotTriples,?.,?triplesTemplate]"],
       TRUE: ["?triplesTemplate", "*[quadsNotTriples,?.,?triplesTemplate]"],
       FALSE: ["?triplesTemplate", "*[quadsNotTriples,?.,?triplesTemplate]"],
       BLANK_NODE_LABEL: ["?triplesTemplate", "*[quadsNotTriples,?.,?triplesTemplate]"],
       ANON: ["?triplesTemplate", "*[quadsNotTriples,?.,?triplesTemplate]"],
+      "(": ["?triplesTemplate", "*[quadsNotTriples,?.,?triplesTemplate]"],
+      "[": ["?triplesTemplate", "*[quadsNotTriples,?.,?triplesTemplate]"],
       PNAME_LN: ["?triplesTemplate", "*[quadsNotTriples,?.,?triplesTemplate]"],
       PNAME_NS: ["?triplesTemplate", "*[quadsNotTriples,?.,?triplesTemplate]"],
       STRING_LITERAL1: ["?triplesTemplate", "*[quadsNotTriples,?.,?triplesTemplate]"],
@@ -3932,376 +4881,406 @@ module.exports = {
       INTEGER_NEGATIVE: ["?triplesTemplate", "*[quadsNotTriples,?.,?triplesTemplate]"],
       DECIMAL_NEGATIVE: ["?triplesTemplate", "*[quadsNotTriples,?.,?triplesTemplate]"],
       DOUBLE_NEGATIVE: ["?triplesTemplate", "*[quadsNotTriples,?.,?triplesTemplate]"],
-      "}": ["?triplesTemplate", "*[quadsNotTriples,?.,?triplesTemplate]"]
+      "}": ["?triplesTemplate", "*[quadsNotTriples,?.,?triplesTemplate]"],
     },
     quadsNotTriples: {
-      GRAPH: ["GRAPH", "varOrIRIref", "{", "?triplesTemplate", "}"]
+      GRAPH: ["GRAPH", "varOrIRIref", "{", "?triplesTemplate", "}"],
     },
     queryAll: {
       CONSTRUCT: ["or([selectQuery,constructQuery,describeQuery,askQuery])", "valuesClause"],
       DESCRIBE: ["or([selectQuery,constructQuery,describeQuery,askQuery])", "valuesClause"],
       ASK: ["or([selectQuery,constructQuery,describeQuery,askQuery])", "valuesClause"],
-      SELECT: ["or([selectQuery,constructQuery,describeQuery,askQuery])", "valuesClause"]
+      SELECT: ["or([selectQuery,constructQuery,describeQuery,askQuery])", "valuesClause"],
+    },
+    quotedTP: {
+      "<<": ["<<", "qtSubjectOrObject", "verb", "qtSubjectOrObject", ">>"],
+    },
+    quotedTriple: {
+      "<<": ["<<", "dataValueTerm", "or([iriRef,a])", "dataValueTerm", ">>"],
     },
     rdfLiteral: {
       STRING_LITERAL1: ["string", "?or([LANGTAG,[^^,iriRef]])"],
       STRING_LITERAL2: ["string", "?or([LANGTAG,[^^,iriRef]])"],
       STRING_LITERAL_LONG1: ["string", "?or([LANGTAG,[^^,iriRef]])"],
-      STRING_LITERAL_LONG2: ["string", "?or([LANGTAG,[^^,iriRef]])"]
+      STRING_LITERAL_LONG2: ["string", "?or([LANGTAG,[^^,iriRef]])"],
     },
     regexExpression: {
-      REGEX: ["REGEX", "(", "expression", ",", "expression", "?[,,expression]", ")"]
+      REGEX: ["REGEX", "(", "expression", ",", "expression", "?[,,expression]", ")"],
     },
     relationalExpression: {
       "!": [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       "+": [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       "-": [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       VAR1: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       VAR2: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       "(": [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       STR: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       LANG: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       LANGMATCHES: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       DATATYPE: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       BOUND: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       IRI: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       URI: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       BNODE: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       RAND: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       ABS: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       CEIL: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       FLOOR: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       ROUND: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       CONCAT: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       STRLEN: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       UCASE: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       LCASE: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       ENCODE_FOR_URI: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       CONTAINS: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       STRSTARTS: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       STRENDS: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       STRBEFORE: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       STRAFTER: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       YEAR: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       MONTH: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       DAY: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       HOURS: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       MINUTES: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       SECONDS: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       TIMEZONE: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       TZ: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       NOW: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       UUID: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       STRUUID: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       MD5: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       SHA1: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       SHA256: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       SHA384: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       SHA512: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       COALESCE: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       IF: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       STRLANG: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       STRDT: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       SAMETERM: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       ISIRI: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       ISURI: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       ISBLANK: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       ISLITERAL: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       ISNUMERIC: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
+      ],
+      TRIPLE: [
+        "numericExpression",
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
+      ],
+      SUBJECT: [
+        "numericExpression",
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
+      ],
+      PREDICATE: [
+        "numericExpression",
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
+      ],
+      OBJECT: [
+        "numericExpression",
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
+      ],
+      isTRIPLE: [
+        "numericExpression",
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       TRUE: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       FALSE: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
+      ],
+      "<<": [
+        "numericExpression",
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       COUNT: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       SUM: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       MIN: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       MAX: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       AVG: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       SAMPLE: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       GROUP_CONCAT: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       SUBSTR: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       REPLACE: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       REGEX: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       EXISTS: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       NOT: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       IRI_REF: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       STRING_LITERAL1: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       STRING_LITERAL2: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       STRING_LITERAL_LONG1: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       STRING_LITERAL_LONG2: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       INTEGER: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       DECIMAL: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       DOUBLE: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       INTEGER_POSITIVE: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       DECIMAL_POSITIVE: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       DOUBLE_POSITIVE: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       INTEGER_NEGATIVE: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       DECIMAL_NEGATIVE: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       DOUBLE_NEGATIVE: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       PNAME_LN: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
       ],
       PNAME_NS: [
         "numericExpression",
-        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])"
-      ]
+        "?or([[=,numericExpression],[!=,numericExpression],[<,numericExpression],[>,numericExpression],[<=,numericExpression],[>=,numericExpression],[IN,expressionList],[NOT,IN,expressionList]])",
+      ],
     },
     selectClause: {
-      SELECT: ["SELECT", "?or([DISTINCT,REDUCED])", "or([+or([var,[(,expression,AS,var,)]]),*])"]
+      SELECT: ["SELECT", "?or([DISTINCT,REDUCED])", "or([+or([var,[(,expression,AS,var,)]]),*])"],
     },
     selectQuery: {
-      SELECT: ["selectClause", "*datasetClause", "whereClause", "solutionModifier"]
+      SELECT: ["selectClause", "*datasetClause", "whereClause", "solutionModifier"],
     },
     serviceGraphPattern: {
-      SERVICE: ["SERVICE", "?SILENT", "varOrIRIref", "groupGraphPattern"]
+      SERVICE: ["SERVICE", "?SILENT", "varOrIRIref", "groupGraphPattern"],
     },
     solutionModifier: {
       LIMIT: ["?groupClause", "?havingClause", "?orderClause", "?limitOffsetClauses"],
@@ -4311,12 +5290,12 @@ module.exports = {
       GROUP: ["?groupClause", "?havingClause", "?orderClause", "?limitOffsetClauses"],
       VALUES: ["?groupClause", "?havingClause", "?orderClause", "?limitOffsetClauses"],
       $: ["?groupClause", "?havingClause", "?orderClause", "?limitOffsetClauses"],
-      "}": ["?groupClause", "?havingClause", "?orderClause", "?limitOffsetClauses"]
+      "}": ["?groupClause", "?havingClause", "?orderClause", "?limitOffsetClauses"],
     },
     sourceSelector: {
       IRI_REF: ["iriRef"],
       PNAME_LN: ["iriRef"],
-      PNAME_NS: ["iriRef"]
+      PNAME_NS: ["iriRef"],
     },
     sparql11: {
       $: ["prologue", "or([queryAll,updateAll])", "$"],
@@ -4335,7 +5314,7 @@ module.exports = {
       CREATE: ["prologue", "or([queryAll,updateAll])", "$"],
       WITH: ["prologue", "or([queryAll,updateAll])", "$"],
       BASE: ["prologue", "or([queryAll,updateAll])", "$"],
-      PREFIX: ["prologue", "or([queryAll,updateAll])", "$"]
+      PREFIX: ["prologue", "or([queryAll,updateAll])", "$"],
     },
     storeProperty: {
       VAR1: [],
@@ -4343,34 +5322,35 @@ module.exports = {
       IRI_REF: [],
       PNAME_LN: [],
       PNAME_NS: [],
-      a: []
+      a: [],
     },
     strReplaceExpression: {
-      REPLACE: ["REPLACE", "(", "expression", ",", "expression", ",", "expression", "?[,,expression]", ")"]
+      REPLACE: ["REPLACE", "(", "expression", ",", "expression", ",", "expression", "?[,,expression]", ")"],
     },
     string: {
       STRING_LITERAL1: ["STRING_LITERAL1"],
       STRING_LITERAL2: ["STRING_LITERAL2"],
       STRING_LITERAL_LONG1: ["STRING_LITERAL_LONG1"],
-      STRING_LITERAL_LONG2: ["STRING_LITERAL_LONG2"]
+      STRING_LITERAL_LONG2: ["STRING_LITERAL_LONG2"],
     },
     subSelect: {
-      SELECT: ["selectClause", "whereClause", "solutionModifier", "valuesClause"]
+      SELECT: ["selectClause", "whereClause", "solutionModifier", "valuesClause"],
     },
     substringExpression: {
-      SUBSTR: ["SUBSTR", "(", "expression", ",", "expression", "?[,,expression]", ")"]
+      SUBSTR: ["SUBSTR", "(", "expression", ",", "expression", "?[,,expression]", ")"],
     },
     triplesBlock: {
       VAR1: ["triplesSameSubjectPath", "?[.,?triplesBlock]"],
       VAR2: ["triplesSameSubjectPath", "?[.,?triplesBlock]"],
       NIL: ["triplesSameSubjectPath", "?[.,?triplesBlock]"],
-      "(": ["triplesSameSubjectPath", "?[.,?triplesBlock]"],
-      "[": ["triplesSameSubjectPath", "?[.,?triplesBlock]"],
+      "<<": ["triplesSameSubjectPath", "?[.,?triplesBlock]"],
       IRI_REF: ["triplesSameSubjectPath", "?[.,?triplesBlock]"],
       TRUE: ["triplesSameSubjectPath", "?[.,?triplesBlock]"],
       FALSE: ["triplesSameSubjectPath", "?[.,?triplesBlock]"],
       BLANK_NODE_LABEL: ["triplesSameSubjectPath", "?[.,?triplesBlock]"],
       ANON: ["triplesSameSubjectPath", "?[.,?triplesBlock]"],
+      "(": ["triplesSameSubjectPath", "?[.,?triplesBlock]"],
+      "[": ["triplesSameSubjectPath", "?[.,?triplesBlock]"],
       PNAME_LN: ["triplesSameSubjectPath", "?[.,?triplesBlock]"],
       PNAME_NS: ["triplesSameSubjectPath", "?[.,?triplesBlock]"],
       STRING_LITERAL1: ["triplesSameSubjectPath", "?[.,?triplesBlock]"],
@@ -4385,81 +5365,84 @@ module.exports = {
       DOUBLE_POSITIVE: ["triplesSameSubjectPath", "?[.,?triplesBlock]"],
       INTEGER_NEGATIVE: ["triplesSameSubjectPath", "?[.,?triplesBlock]"],
       DECIMAL_NEGATIVE: ["triplesSameSubjectPath", "?[.,?triplesBlock]"],
-      DOUBLE_NEGATIVE: ["triplesSameSubjectPath", "?[.,?triplesBlock]"]
+      DOUBLE_NEGATIVE: ["triplesSameSubjectPath", "?[.,?triplesBlock]"],
     },
     triplesNode: {
       "(": ["collection"],
-      "[": ["blankNodePropertyList"]
+      "[": ["blankNodePropertyList"],
     },
     triplesNodePath: {
       "(": ["collectionPath"],
-      "[": ["blankNodePropertyListPath"]
+      "[": ["blankNodePropertyListPath"],
     },
     triplesSameSubject: {
-      VAR1: ["varOrTerm", "propertyListNotEmpty"],
-      VAR2: ["varOrTerm", "propertyListNotEmpty"],
-      NIL: ["varOrTerm", "propertyListNotEmpty"],
-      IRI_REF: ["varOrTerm", "propertyListNotEmpty"],
-      TRUE: ["varOrTerm", "propertyListNotEmpty"],
-      FALSE: ["varOrTerm", "propertyListNotEmpty"],
-      BLANK_NODE_LABEL: ["varOrTerm", "propertyListNotEmpty"],
-      ANON: ["varOrTerm", "propertyListNotEmpty"],
-      PNAME_LN: ["varOrTerm", "propertyListNotEmpty"],
-      PNAME_NS: ["varOrTerm", "propertyListNotEmpty"],
-      STRING_LITERAL1: ["varOrTerm", "propertyListNotEmpty"],
-      STRING_LITERAL2: ["varOrTerm", "propertyListNotEmpty"],
-      STRING_LITERAL_LONG1: ["varOrTerm", "propertyListNotEmpty"],
-      STRING_LITERAL_LONG2: ["varOrTerm", "propertyListNotEmpty"],
-      INTEGER: ["varOrTerm", "propertyListNotEmpty"],
-      DECIMAL: ["varOrTerm", "propertyListNotEmpty"],
-      DOUBLE: ["varOrTerm", "propertyListNotEmpty"],
-      INTEGER_POSITIVE: ["varOrTerm", "propertyListNotEmpty"],
-      DECIMAL_POSITIVE: ["varOrTerm", "propertyListNotEmpty"],
-      DOUBLE_POSITIVE: ["varOrTerm", "propertyListNotEmpty"],
-      INTEGER_NEGATIVE: ["varOrTerm", "propertyListNotEmpty"],
-      DECIMAL_NEGATIVE: ["varOrTerm", "propertyListNotEmpty"],
-      DOUBLE_NEGATIVE: ["varOrTerm", "propertyListNotEmpty"],
+      VAR1: ["varOrTermOrQuotedTP", "propertyListNotEmpty"],
+      VAR2: ["varOrTermOrQuotedTP", "propertyListNotEmpty"],
+      NIL: ["varOrTermOrQuotedTP", "propertyListNotEmpty"],
+      "<<": ["varOrTermOrQuotedTP", "propertyListNotEmpty"],
+      IRI_REF: ["varOrTermOrQuotedTP", "propertyListNotEmpty"],
+      TRUE: ["varOrTermOrQuotedTP", "propertyListNotEmpty"],
+      FALSE: ["varOrTermOrQuotedTP", "propertyListNotEmpty"],
+      BLANK_NODE_LABEL: ["varOrTermOrQuotedTP", "propertyListNotEmpty"],
+      ANON: ["varOrTermOrQuotedTP", "propertyListNotEmpty"],
+      PNAME_LN: ["varOrTermOrQuotedTP", "propertyListNotEmpty"],
+      PNAME_NS: ["varOrTermOrQuotedTP", "propertyListNotEmpty"],
+      STRING_LITERAL1: ["varOrTermOrQuotedTP", "propertyListNotEmpty"],
+      STRING_LITERAL2: ["varOrTermOrQuotedTP", "propertyListNotEmpty"],
+      STRING_LITERAL_LONG1: ["varOrTermOrQuotedTP", "propertyListNotEmpty"],
+      STRING_LITERAL_LONG2: ["varOrTermOrQuotedTP", "propertyListNotEmpty"],
+      INTEGER: ["varOrTermOrQuotedTP", "propertyListNotEmpty"],
+      DECIMAL: ["varOrTermOrQuotedTP", "propertyListNotEmpty"],
+      DOUBLE: ["varOrTermOrQuotedTP", "propertyListNotEmpty"],
+      INTEGER_POSITIVE: ["varOrTermOrQuotedTP", "propertyListNotEmpty"],
+      DECIMAL_POSITIVE: ["varOrTermOrQuotedTP", "propertyListNotEmpty"],
+      DOUBLE_POSITIVE: ["varOrTermOrQuotedTP", "propertyListNotEmpty"],
+      INTEGER_NEGATIVE: ["varOrTermOrQuotedTP", "propertyListNotEmpty"],
+      DECIMAL_NEGATIVE: ["varOrTermOrQuotedTP", "propertyListNotEmpty"],
+      DOUBLE_NEGATIVE: ["varOrTermOrQuotedTP", "propertyListNotEmpty"],
       "(": ["triplesNode", "propertyList"],
-      "[": ["triplesNode", "propertyList"]
+      "[": ["triplesNode", "propertyList"],
     },
     triplesSameSubjectPath: {
-      VAR1: ["varOrTerm", "propertyListPathNotEmpty"],
-      VAR2: ["varOrTerm", "propertyListPathNotEmpty"],
-      NIL: ["varOrTerm", "propertyListPathNotEmpty"],
-      IRI_REF: ["varOrTerm", "propertyListPathNotEmpty"],
-      TRUE: ["varOrTerm", "propertyListPathNotEmpty"],
-      FALSE: ["varOrTerm", "propertyListPathNotEmpty"],
-      BLANK_NODE_LABEL: ["varOrTerm", "propertyListPathNotEmpty"],
-      ANON: ["varOrTerm", "propertyListPathNotEmpty"],
-      PNAME_LN: ["varOrTerm", "propertyListPathNotEmpty"],
-      PNAME_NS: ["varOrTerm", "propertyListPathNotEmpty"],
-      STRING_LITERAL1: ["varOrTerm", "propertyListPathNotEmpty"],
-      STRING_LITERAL2: ["varOrTerm", "propertyListPathNotEmpty"],
-      STRING_LITERAL_LONG1: ["varOrTerm", "propertyListPathNotEmpty"],
-      STRING_LITERAL_LONG2: ["varOrTerm", "propertyListPathNotEmpty"],
-      INTEGER: ["varOrTerm", "propertyListPathNotEmpty"],
-      DECIMAL: ["varOrTerm", "propertyListPathNotEmpty"],
-      DOUBLE: ["varOrTerm", "propertyListPathNotEmpty"],
-      INTEGER_POSITIVE: ["varOrTerm", "propertyListPathNotEmpty"],
-      DECIMAL_POSITIVE: ["varOrTerm", "propertyListPathNotEmpty"],
-      DOUBLE_POSITIVE: ["varOrTerm", "propertyListPathNotEmpty"],
-      INTEGER_NEGATIVE: ["varOrTerm", "propertyListPathNotEmpty"],
-      DECIMAL_NEGATIVE: ["varOrTerm", "propertyListPathNotEmpty"],
-      DOUBLE_NEGATIVE: ["varOrTerm", "propertyListPathNotEmpty"],
+      VAR1: ["varOrTermOrQuotedTP", "propertyListPathNotEmpty"],
+      VAR2: ["varOrTermOrQuotedTP", "propertyListPathNotEmpty"],
+      NIL: ["varOrTermOrQuotedTP", "propertyListPathNotEmpty"],
+      "<<": ["varOrTermOrQuotedTP", "propertyListPathNotEmpty"],
+      IRI_REF: ["varOrTermOrQuotedTP", "propertyListPathNotEmpty"],
+      TRUE: ["varOrTermOrQuotedTP", "propertyListPathNotEmpty"],
+      FALSE: ["varOrTermOrQuotedTP", "propertyListPathNotEmpty"],
+      BLANK_NODE_LABEL: ["varOrTermOrQuotedTP", "propertyListPathNotEmpty"],
+      ANON: ["varOrTermOrQuotedTP", "propertyListPathNotEmpty"],
+      PNAME_LN: ["varOrTermOrQuotedTP", "propertyListPathNotEmpty"],
+      PNAME_NS: ["varOrTermOrQuotedTP", "propertyListPathNotEmpty"],
+      STRING_LITERAL1: ["varOrTermOrQuotedTP", "propertyListPathNotEmpty"],
+      STRING_LITERAL2: ["varOrTermOrQuotedTP", "propertyListPathNotEmpty"],
+      STRING_LITERAL_LONG1: ["varOrTermOrQuotedTP", "propertyListPathNotEmpty"],
+      STRING_LITERAL_LONG2: ["varOrTermOrQuotedTP", "propertyListPathNotEmpty"],
+      INTEGER: ["varOrTermOrQuotedTP", "propertyListPathNotEmpty"],
+      DECIMAL: ["varOrTermOrQuotedTP", "propertyListPathNotEmpty"],
+      DOUBLE: ["varOrTermOrQuotedTP", "propertyListPathNotEmpty"],
+      INTEGER_POSITIVE: ["varOrTermOrQuotedTP", "propertyListPathNotEmpty"],
+      DECIMAL_POSITIVE: ["varOrTermOrQuotedTP", "propertyListPathNotEmpty"],
+      DOUBLE_POSITIVE: ["varOrTermOrQuotedTP", "propertyListPathNotEmpty"],
+      INTEGER_NEGATIVE: ["varOrTermOrQuotedTP", "propertyListPathNotEmpty"],
+      DECIMAL_NEGATIVE: ["varOrTermOrQuotedTP", "propertyListPathNotEmpty"],
+      DOUBLE_NEGATIVE: ["varOrTermOrQuotedTP", "propertyListPathNotEmpty"],
       "(": ["triplesNodePath", "propertyListPath"],
-      "[": ["triplesNodePath", "propertyListPath"]
+      "[": ["triplesNodePath", "propertyListPath"],
     },
     triplesTemplate: {
       VAR1: ["triplesSameSubject", "?[.,?triplesTemplate]"],
       VAR2: ["triplesSameSubject", "?[.,?triplesTemplate]"],
       NIL: ["triplesSameSubject", "?[.,?triplesTemplate]"],
-      "(": ["triplesSameSubject", "?[.,?triplesTemplate]"],
-      "[": ["triplesSameSubject", "?[.,?triplesTemplate]"],
+      "<<": ["triplesSameSubject", "?[.,?triplesTemplate]"],
       IRI_REF: ["triplesSameSubject", "?[.,?triplesTemplate]"],
       TRUE: ["triplesSameSubject", "?[.,?triplesTemplate]"],
       FALSE: ["triplesSameSubject", "?[.,?triplesTemplate]"],
       BLANK_NODE_LABEL: ["triplesSameSubject", "?[.,?triplesTemplate]"],
       ANON: ["triplesSameSubject", "?[.,?triplesTemplate]"],
+      "(": ["triplesSameSubject", "?[.,?triplesTemplate]"],
+      "[": ["triplesSameSubject", "?[.,?triplesTemplate]"],
       PNAME_LN: ["triplesSameSubject", "?[.,?triplesTemplate]"],
       PNAME_NS: ["triplesSameSubject", "?[.,?triplesTemplate]"],
       STRING_LITERAL1: ["triplesSameSubject", "?[.,?triplesTemplate]"],
@@ -4474,7 +5457,7 @@ module.exports = {
       DOUBLE_POSITIVE: ["triplesSameSubject", "?[.,?triplesTemplate]"],
       INTEGER_NEGATIVE: ["triplesSameSubject", "?[.,?triplesTemplate]"],
       DECIMAL_NEGATIVE: ["triplesSameSubject", "?[.,?triplesTemplate]"],
-      DOUBLE_NEGATIVE: ["triplesSameSubject", "?[.,?triplesTemplate]"]
+      DOUBLE_NEGATIVE: ["triplesSameSubject", "?[.,?triplesTemplate]"],
     },
     unaryExpression: {
       "!": ["!", "primaryExpression"],
@@ -4532,8 +5515,14 @@ module.exports = {
       ISBLANK: ["primaryExpression"],
       ISLITERAL: ["primaryExpression"],
       ISNUMERIC: ["primaryExpression"],
+      TRIPLE: ["primaryExpression"],
+      SUBJECT: ["primaryExpression"],
+      PREDICATE: ["primaryExpression"],
+      OBJECT: ["primaryExpression"],
+      isTRIPLE: ["primaryExpression"],
       TRUE: ["primaryExpression"],
       FALSE: ["primaryExpression"],
+      "<<": ["primaryExpression"],
       COUNT: ["primaryExpression"],
       SUM: ["primaryExpression"],
       MIN: ["primaryExpression"],
@@ -4561,7 +5550,7 @@ module.exports = {
       DECIMAL_NEGATIVE: ["primaryExpression"],
       DOUBLE_NEGATIVE: ["primaryExpression"],
       PNAME_LN: ["primaryExpression"],
-      PNAME_NS: ["primaryExpression"]
+      PNAME_NS: ["primaryExpression"],
     },
     update: {
       INSERT: ["prologue", "?[update1,?[;,update]]"],
@@ -4576,7 +5565,7 @@ module.exports = {
       WITH: ["prologue", "?[update1,?[;,update]]"],
       BASE: ["prologue", "?[update1,?[;,update]]"],
       PREFIX: ["prologue", "?[update1,?[;,update]]"],
-      $: ["prologue", "?[update1,?[;,update]]"]
+      $: ["prologue", "?[update1,?[;,update]]"],
     },
     update1: {
       LOAD: ["load"],
@@ -4588,7 +5577,7 @@ module.exports = {
       CREATE: ["create"],
       INSERT: ["INSERT", "insert1"],
       DELETE: ["DELETE", "delete1"],
-      WITH: ["modify"]
+      WITH: ["modify"],
     },
     updateAll: {
       INSERT: ["?[update1,?[;,update]]"],
@@ -4601,10 +5590,10 @@ module.exports = {
       COPY: ["?[update1,?[;,update]]"],
       CREATE: ["?[update1,?[;,update]]"],
       WITH: ["?[update1,?[;,update]]"],
-      $: ["?[update1,?[;,update]]"]
+      $: ["?[update1,?[;,update]]"],
     },
     usingClause: {
-      USING: ["USING", "or([iriRef,[NAMED,iriRef]])"]
+      USING: ["USING", "or([iriRef,[NAMED,iriRef]])"],
     },
     valueLogical: {
       "!": ["relationalExpression"],
@@ -4662,8 +5651,14 @@ module.exports = {
       ISBLANK: ["relationalExpression"],
       ISLITERAL: ["relationalExpression"],
       ISNUMERIC: ["relationalExpression"],
+      TRIPLE: ["relationalExpression"],
+      SUBJECT: ["relationalExpression"],
+      PREDICATE: ["relationalExpression"],
+      OBJECT: ["relationalExpression"],
+      isTRIPLE: ["relationalExpression"],
       TRUE: ["relationalExpression"],
       FALSE: ["relationalExpression"],
+      "<<": ["relationalExpression"],
       COUNT: ["relationalExpression"],
       SUM: ["relationalExpression"],
       MIN: ["relationalExpression"],
@@ -4691,25 +5686,25 @@ module.exports = {
       DECIMAL_NEGATIVE: ["relationalExpression"],
       DOUBLE_NEGATIVE: ["relationalExpression"],
       PNAME_LN: ["relationalExpression"],
-      PNAME_NS: ["relationalExpression"]
+      PNAME_NS: ["relationalExpression"],
     },
     valuesClause: {
       VALUES: ["VALUES", "dataBlock"],
       $: [],
-      "}": []
+      "}": [],
     },
     var: {
       VAR1: ["VAR1"],
-      VAR2: ["VAR2"]
+      VAR2: ["VAR2"],
     },
     varOrIRIref: {
       VAR1: ["var"],
       VAR2: ["var"],
       IRI_REF: ["iriRef"],
       PNAME_LN: ["iriRef"],
-      PNAME_NS: ["iriRef"]
+      PNAME_NS: ["iriRef"],
     },
-    varOrTerm: {
+    varOrTermOrQuotedTP: {
       VAR1: ["var"],
       VAR2: ["var"],
       NIL: ["graphTerm"],
@@ -4732,7 +5727,8 @@ module.exports = {
       DOUBLE_POSITIVE: ["graphTerm"],
       INTEGER_NEGATIVE: ["graphTerm"],
       DECIMAL_NEGATIVE: ["graphTerm"],
-      DOUBLE_NEGATIVE: ["graphTerm"]
+      DOUBLE_NEGATIVE: ["graphTerm"],
+      "<<": ["quotedTP"],
     },
     verb: {
       VAR1: ["storeProperty", "varOrIRIref"],
@@ -4740,7 +5736,7 @@ module.exports = {
       IRI_REF: ["storeProperty", "varOrIRIref"],
       PNAME_LN: ["storeProperty", "varOrIRIref"],
       PNAME_NS: ["storeProperty", "varOrIRIref"],
-      a: ["storeProperty", "a"]
+      a: ["storeProperty", "a"],
     },
     verbPath: {
       "^": ["path"],
@@ -4749,22 +5745,22 @@ module.exports = {
       "(": ["path"],
       IRI_REF: ["path"],
       PNAME_LN: ["path"],
-      PNAME_NS: ["path"]
+      PNAME_NS: ["path"],
     },
     verbSimple: {
       VAR1: ["var"],
-      VAR2: ["var"]
+      VAR2: ["var"],
     },
     whereClause: {
       "{": ["?WHERE", "groupGraphPattern"],
-      WHERE: ["?WHERE", "groupGraphPattern"]
-    }
+      WHERE: ["?WHERE", "groupGraphPattern"],
+    },
   },
 
-  keywords: /^(GROUP_CONCAT|DATATYPE|BASE|PREFIX|SELECT|CONSTRUCT|DESCRIBE|ASK|FROM|NAMED|ORDER|BY|LIMIT|ASC|DESC|OFFSET|DISTINCT|REDUCED|WHERE|GRAPH|OPTIONAL|UNION|FILTER|GROUP|HAVING|AS|VALUES|LOAD|CLEAR|DROP|CREATE|MOVE|COPY|SILENT|INSERT|DELETE|DATA|WITH|TO|USING|NAMED|MINUS|BIND|LANGMATCHES|LANG|BOUND|SAMETERM|ISIRI|ISURI|ISBLANK|ISLITERAL|REGEX|TRUE|FALSE|UNDEF|ADD|DEFAULT|ALL|SERVICE|INTO|IN|NOT|IRI|URI|BNODE|RAND|ABS|CEIL|FLOOR|ROUND|CONCAT|STRLEN|UCASE|LCASE|ENCODE_FOR_URI|CONTAINS|STRSTARTS|STRENDS|STRBEFORE|STRAFTER|YEAR|MONTH|DAY|HOURS|MINUTES|SECONDS|TIMEZONE|TZ|NOW|UUID|STRUUID|MD5|SHA1|SHA256|SHA384|SHA512|COALESCE|IF|STRLANG|STRDT|ISNUMERIC|SUBSTR|REPLACE|EXISTS|COUNT|SUM|MIN|MAX|AVG|SAMPLE|SEPARATOR|STR)/i,
+  keywords: /^(GROUP_CONCAT|DATATYPE|BASE|PREFIX|SELECT|CONSTRUCT|DESCRIBE|ASK|FROM|NAMED|ORDER|BY|LIMIT|ASC|DESC|OFFSET|DISTINCT|REDUCED|WHERE|GRAPH|OPTIONAL|UNION|FILTER|GROUP|HAVING|AS|VALUES|LOAD|CLEAR|DROP|CREATE|MOVE|COPY|SILENT|INSERT|DELETE|DATA|WITH|TO|USING|NAMED|MINUS|BIND|LANGMATCHES|LANG|BOUND|SAMETERM|ISIRI|ISURI|ISBLANK|ISLITERAL|REGEX|TRUE|FALSE|UNDEF|ADD|DEFAULT|ALL|SERVICE|INTO|IN|NOT|IRI|URI|BNODE|RAND|ABS|CEIL|FLOOR|ROUND|CONCAT|STRLEN|UCASE|LCASE|ENCODE_FOR_URI|CONTAINS|STRSTARTS|STRENDS|STRBEFORE|STRAFTER|YEAR|MONTH|DAY|HOURS|MINUTES|SECONDS|TIMEZONE|TZ|NOW|UUID|STRUUID|MD5|SHA1|SHA256|SHA384|SHA512|COALESCE|IF|STRLANG|STRDT|ISNUMERIC|SUBSTR|REPLACE|EXISTS|COUNT|SUM|MIN|MAX|AVG|SAMPLE|SEPARATOR|STR|TRIPLE|SUBJECT|PREDICATE|OBJECT|isTRIPLE)/i,
 
-  punct: /^(\*|a|\.|\{|\}|,|\(|\)|;|\[|\]|\|\||&&|=|!=|!|<=|>=|<|>|\+|-|\/|\^\^|\?|\||\^)/,
+  punct: /^(<<|>>|\{\||\|\}|\*|a|\.|\{|\}|,|\(|\)|;|\[|\]|\|\||&&|=|!=|!|<=|>=|<|>|\+|-|\/|\^\^|\?|\||\^)/,
 
   startSymbol: "sparql11",
-  acceptEmpty: true
+  acceptEmpty: true,
 };

--- a/packages/yasqe/grammar/build.sh
+++ b/packages/yasqe/grammar/build.sh
@@ -1,2 +1,10 @@
 #!/bin/bash
-swipl  -s util/gen_sparql11.pl -t go
+set -eu
+
+docker pull swipl:7.5.11
+docker container run --rm \
+  --volume $(pwd -P):/app \
+  --workdir /app \
+  --user 1000:1000 \
+  swipl:7.5.11 \
+  swipl -s /app/util/gen_sparql11.pl -t go

--- a/packages/yasr/src/plugins/table/index.ts
+++ b/packages/yasr/src/plugins/table/index.ts
@@ -100,8 +100,7 @@ export default class Table implements Plugin<PluginConfig> {
     return bindings.map((binding, rowId) => [rowId + 1, ...vars.map((variable) => binding[variable] ?? "")]);
   }
 
-  private getUriLinkFromBinding(binding: Parser.BindingValue, prefixes?: { [key: string]: string }) {
-    const href = binding.value;
+  private getUriLinkFromBinding(href: string, prefixes?: { [key: string]: string }) {
     let visibleString = href;
     let prefixed = false;
     if (prefixes) {
@@ -124,7 +123,7 @@ export default class Table implements Plugin<PluginConfig> {
   private getCellContent(binding: Parser.BindingValue, prefixes?: { [label: string]: string }): string {
     let content: string;
     if (binding.type == "uri") {
-      content = `<span>${this.getUriLinkFromBinding(binding, prefixes)}</span>`;
+      content = `<span>${this.getUriLinkFromBinding(binding.value as string, prefixes)}</span>`;
     } else {
       content = `<span class='nonIri'>${this.formatLiteral(binding, prefixes)}</span>`;
     }
@@ -132,14 +131,15 @@ export default class Table implements Plugin<PluginConfig> {
     return `<div>${content}</div>`;
   }
   private formatLiteral(literalBinding: Parser.BindingValue, prefixes?: { [key: string]: string }) {
-    let stringRepresentation = escape(literalBinding.value);
+    const literalValue = Parser.getBindingValueValueAsString(literalBinding.value);
+    let stringRepresentation = escape(literalValue);
     // Return now when in compact mode.
     if (this.persistentConfig.compact) return stringRepresentation;
 
     if (literalBinding["xml:lang"]) {
       stringRepresentation = `"${stringRepresentation}"<sup>@${literalBinding["xml:lang"]}</sup>`;
     } else if (literalBinding.datatype) {
-      const dataType = this.getUriLinkFromBinding({ type: "uri", value: literalBinding.datatype }, prefixes);
+      const dataType = this.getUriLinkFromBinding(literalBinding.datatype, prefixes);
       stringRepresentation = `"${stringRepresentation}"<sup>^^${dataType}</sup>`;
     }
     return stringRepresentation;


### PR DESCRIPTION
Closes #190 

This draft pull request includes the commit from #214 , in order for the build to pass. If that other PR is merged, I will drop the commit here and rebase onto `master`.

- [x] SPARQL Grammar
- [x] SPARQL Query Results

The other commit, right now, adds the [SPARQL grammar](https://www.w3.org/2021/12/rdf-star.html#sparql-star-grammar) (thanks @afs for the link) to the Prolog database. I regenerated the tokenizer table, used by CodeMirror, with SWI-Prolog and tested locally in YASGUI. You can see it in action with the YASQE editor in these screenshots:

![Screenshot from 2023-01-23 20-40-49](https://user-images.githubusercontent.com/304786/214140962-8f98c1ad-12b8-4bd7-bad2-ea3c524cabde.png)
![Screenshot from 2023-01-23 20-56-19](https://user-images.githubusercontent.com/304786/214140967-3777280d-8052-4172-afd8-60c6dc214e5b.png)

I've also tested successfully in Jena. This screenshot shows the current behavior (running `FusekiCmd` from Eclipse, port `3030`):

![image](https://user-images.githubusercontent.com/304786/214141338-20bcd68f-a4c8-42a9-ab6d-bf4adb54c69b.png)

And this one shows the Fuseki UI using the local development version of YASGUI (I removed `triply/yasqe` from Jena Fuseki UI, then `yarn add /home/kinow/.../yasqe`, running Yarn using port `8080`, proxying Fuseki requests to the port `3030` - i.e. Fuseki UI dev mode, same data & backend, different UI only):

![image](https://user-images.githubusercontent.com/304786/214141731-e7940d7f-3061-4e0b-99f9-8a7d57c220f6.png)

I loaded a simple Turtle file into a dataset in Jena:

```ttl
PREFIX : <http://example/directory>
PREFIX dct: <http://purl.org/dc/terms/>
PREFIX foaf: <http://xmlns.com/foaf/0.1/>

<< :john foaf:name "John Smith" >> dct:source <http://example/directory> .
```

to query and produce some RDF-Star results. At the moment it shows a JavaScript error in the query results panel (“e[t].value.replace is not a function”).

![image](https://user-images.githubusercontent.com/304786/214142008-2127f8e5-93aa-4b26-a8b9-409f83fde074.png)

So that's the only part pending, but I think the hardest part was the Prolog parser and getting it working with YASQE. Now it should be a matter of checking if the type is a triple and displaying it correctly (probably as a quoted triple?).

Cheers
-Bruno