### PR TITLE
fix: Destructure yasqe config at the end to use the surchaged config

### DIFF
--- a/packages/yasgui/src/Tab.ts
+++ b/packages/yasgui/src/Tab.ts
@@ -298,7 +298,6 @@ export class Tab extends EventEmitter {
 
   private initYasqe() {
     const yasqeConf: Partial<YasqeConfig> = {
-      ...this.yasgui.config.yasqe,
       value: this.persistentJson.yasqe.value,
       editorHeight: this.persistentJson.yasqe.editorHeight ? this.persistentJson.yasqe.editorHeight : undefined,
       persistenceId: null, //yasgui handles persistent storing
@@ -337,6 +336,7 @@ export class Tab extends EventEmitter {
         }
         return processedReqConfig as PlainRequestConfig;
       },
+      ...this.yasgui.config.yasqe,
     };
     if (!yasqeConf.hintConfig) {
       yasqeConf.hintConfig = {};


### PR DESCRIPTION
The other way did not let use the yasqe config as
```javascript
new Yasgui(yasguiAnchor, {
    yasqe: {createShareableLink},
})
```